### PR TITLE
feat: 한국 도시설계 토지이용계획 수립 툴 구현

### DIFF
--- a/urban_planner/engine/__init__.py
+++ b/urban_planner/engine/__init__.py
@@ -1,0 +1,22 @@
+"""
+한국 도시설계 토지이용계획 수립 엔진
+Korean Urban Planning Land Use Planning Engine
+"""
+
+from .context_fetcher import ContextFetcher
+from .site_analyzer import SiteAnalyzer
+from .master_planner import MasterPlanner
+from .road_generator import RoadGenerator
+from .block_divider import BlockDivider
+from .facility_placer import FacilityPlacer
+from .validator import PlanValidator
+
+__all__ = [
+    'ContextFetcher',
+    'SiteAnalyzer',
+    'MasterPlanner',
+    'RoadGenerator',
+    'BlockDivider',
+    'FacilityPlacer',
+    'PlanValidator',
+]

--- a/urban_planner/engine/block_divider.py
+++ b/urban_planner/engine/block_divider.py
@@ -1,0 +1,224 @@
+"""
+도로망으로 대상지를 블록으로 분할하는 모듈
+"""
+
+import json
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import shape, Polygon, MultiPolygon, LineString
+from shapely.ops import unary_union, polygonize, split
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+transformer_to_wgs84 = Transformer.from_crs(EPSG_5179, EPSG_WGS84, always_xy=True)
+
+
+class BlockDivider:
+
+    def divide(
+        self,
+        boundary_geojson: dict,
+        road_polygons_gdf: gpd.GeoDataFrame
+    ) -> dict:
+        """
+        도로로 경계 분할하여 블록 생성
+
+        반환:
+        {
+          'blocks_gdf': GeoDataFrame,   # 블록 Polygon들
+          'blocks_geojson': dict,
+          'block_stats': dict
+        }
+
+        blocks_gdf columns:
+        - geometry: Polygon
+        - block_id: str ('B-001' 형식)
+        - area_m2: float
+        - adjacent_road_width_m: float  # 최대 접면도로폭
+        - adjacent_road_count: int      # 접면도로 수
+        - is_corner: bool               # 코너블록 여부
+        - centroid_x: float
+        - centroid_y: float
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            boundary_geom = Polygon(transformed)
+
+            # Get road union
+            if road_polygons_gdf.empty:
+                road_union = None
+            else:
+                try:
+                    road_union = unary_union(road_polygons_gdf.geometry.values)
+                except Exception:
+                    road_union = None
+
+            # Subtract roads from boundary to get buildable area
+            if road_union is not None and not road_union.is_empty:
+                try:
+                    buildable = boundary_geom.difference(road_union)
+                except Exception:
+                    buildable = boundary_geom
+            else:
+                buildable = boundary_geom
+
+            # Extract individual polygons
+            blocks = []
+            if buildable.geom_type == 'Polygon':
+                blocks = [buildable]
+            elif buildable.geom_type == 'MultiPolygon':
+                blocks = list(buildable.geoms)
+            else:
+                # Try to extract polygons from geometry collection
+                for g in buildable.geoms if hasattr(buildable, 'geoms') else []:
+                    if g.geom_type == 'Polygon' and g.area > 100:
+                        blocks.append(g)
+
+            # Filter out very small slivers
+            blocks = [b for b in blocks if b.area > 500 and b.is_valid]
+
+            # If no blocks, return boundary as single block
+            if not blocks:
+                blocks = [boundary_geom]
+
+            # Build GeoDataFrame
+            rows = []
+            for i, block in enumerate(blocks):
+                block_id = f'B-{i+1:03d}'
+                area_m2 = block.area
+                centroid = block.centroid
+
+                adj_road_width = self._get_adjacent_road_width(block, road_polygons_gdf)
+                adj_road_count = self._count_adjacent_roads(block, road_polygons_gdf)
+                is_corner = self._is_corner_block(block, road_polygons_gdf)
+
+                rows.append({
+                    'geometry': block,
+                    'block_id': block_id,
+                    'area_m2': round(area_m2, 1),
+                    'adjacent_road_width_m': adj_road_width,
+                    'adjacent_road_count': adj_road_count,
+                    'is_corner': is_corner,
+                    'centroid_x': round(centroid.x, 1),
+                    'centroid_y': round(centroid.y, 1),
+                })
+
+            blocks_gdf = gpd.GeoDataFrame(rows, crs=f"EPSG:{EPSG_5179}")
+
+            # Calculate stats
+            block_stats = self._calculate_stats(blocks_gdf)
+
+            # Convert to WGS84 GeoJSON
+            blocks_wgs84 = blocks_gdf.to_crs(EPSG_WGS84)
+            blocks_geojson = json.loads(blocks_wgs84.to_json())
+
+            return {
+                'blocks_gdf': blocks_gdf,
+                'blocks_geojson': blocks_geojson,
+                'block_stats': block_stats,
+            }
+
+        except Exception as e:
+            empty_gdf = gpd.GeoDataFrame(
+                columns=['geometry', 'block_id', 'area_m2', 'adjacent_road_width_m',
+                         'adjacent_road_count', 'is_corner', 'centroid_x', 'centroid_y'],
+                crs=f"EPSG:{EPSG_5179}"
+            )
+            return {
+                'blocks_gdf': empty_gdf,
+                'blocks_geojson': {'type': 'FeatureCollection', 'features': []},
+                'block_stats': {},
+            }
+
+    def _get_adjacent_road_width(
+        self,
+        block_geom,
+        road_polygons_gdf: gpd.GeoDataFrame
+    ) -> float:
+        """
+        블록에 접면한 도로 중 최대 폭원 반환
+        접면 기준: 블록 경계와 1m 이내 도로
+        도로 없으면 0.0 반환
+        """
+        if road_polygons_gdf.empty:
+            return 0.0
+
+        try:
+            block_boundary = block_geom.exterior
+            max_width = 0.0
+
+            for idx, row in road_polygons_gdf.iterrows():
+                road_geom = row.geometry
+                if road_geom is None or road_geom.is_empty:
+                    continue
+                dist = block_boundary.distance(road_geom)
+                if dist <= 1.0:
+                    width = float(row.get('width_m', 0))
+                    if width > max_width:
+                        max_width = width
+
+            return max_width
+        except Exception:
+            return 0.0
+
+    def _count_adjacent_roads(
+        self,
+        block_geom,
+        road_polygons_gdf: gpd.GeoDataFrame
+    ) -> int:
+        """접면 도로 개수 반환"""
+        if road_polygons_gdf.empty:
+            return 0
+
+        try:
+            block_boundary = block_geom.exterior
+            count = 0
+
+            for idx, row in road_polygons_gdf.iterrows():
+                road_geom = row.geometry
+                if road_geom is None or road_geom.is_empty:
+                    continue
+                dist = block_boundary.distance(road_geom)
+                if dist <= 1.0:
+                    count += 1
+
+            return count
+        except Exception:
+            return 0
+
+    def _is_corner_block(
+        self,
+        block_geom,
+        road_polygons_gdf: gpd.GeoDataFrame
+    ) -> bool:
+        """
+        2개 이상 도로에 접하면 코너블록
+        """
+        return self._count_adjacent_roads(block_geom, road_polygons_gdf) >= 2
+
+    def _calculate_stats(self, blocks_gdf: gpd.GeoDataFrame) -> dict:
+        """블록 통계"""
+        if blocks_gdf.empty:
+            return {
+                'count': 0,
+                'total_area_m2': 0,
+                'avg_area_m2': 0,
+                'min_area_m2': 0,
+                'max_area_m2': 0,
+                'corner_block_count': 0,
+            }
+
+        areas = blocks_gdf['area_m2']
+        return {
+            'count': len(blocks_gdf),
+            'total_area_m2': round(float(areas.sum()), 1),
+            'avg_area_m2': round(float(areas.mean()), 1),
+            'min_area_m2': round(float(areas.min()), 1),
+            'max_area_m2': round(float(areas.max()), 1),
+            'corner_block_count': int(blocks_gdf['is_corner'].sum()),
+        }

--- a/urban_planner/engine/context_fetcher.py
+++ b/urban_planner/engine/context_fetcher.py
@@ -1,0 +1,613 @@
+"""
+대상지 주변 500m OSM 데이터 수집
+모든 메서드는 아래 시그니처를 정확히 따른다
+"""
+
+import math
+import json
+import requests
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import shape, Point, LineString, Polygon, MultiLineString
+from shapely.ops import unary_union
+from pyproj import Transformer
+
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+# WGS84 → EPSG:5179
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+# EPSG:5179 → WGS84
+transformer_to_wgs84 = Transformer.from_crs(EPSG_5179, EPSG_WGS84, always_xy=True)
+
+
+def _empty_gdf(crs=EPSG_5179) -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(geometry=[], crs=f"EPSG:{crs}")
+
+
+class ContextFetcher:
+
+    def fetch_context(
+        self,
+        boundary_geojson: dict,
+        buffer_m: float = 500
+    ) -> dict:
+        """
+        반환:
+        {
+          'roads_gdf': GeoDataFrame(crs=EPSG:5179),
+          'landuse_gdf': GeoDataFrame(crs=EPSG:5179),
+          'facilities_gdf': GeoDataFrame(crs=EPSG:5179),
+          'subway_stations': list[dict],
+          'bus_stops': list[dict],
+          'entry_points': list[dict],
+          'context_summary': dict
+        }
+        실패시: 빈 GeoDataFrame과 빈 리스트 반환
+        절대 예외 발생시키지 않음
+        """
+        try:
+            bbox = self._boundary_to_bbox(boundary_geojson, buffer_m)
+            osm_data = self._fetch_osm(bbox)
+
+            roads_gdf = self._parse_roads(osm_data)
+            landuse_gdf = self._parse_landuse(osm_data)
+            facilities_gdf = self._parse_facilities(osm_data)
+            subway_stations = self._parse_subway_stations(osm_data)
+            bus_stops = self._parse_bus_stops(osm_data)
+            entry_points = self.get_entry_points(boundary_geojson, roads_gdf)
+
+            context_summary = {
+                'road_count': len(roads_gdf),
+                'landuse_count': len(landuse_gdf),
+                'facility_count': len(facilities_gdf),
+                'subway_count': len(subway_stations),
+                'bus_stop_count': len(bus_stops),
+                'entry_point_count': len(entry_points),
+                'bbox': bbox,
+            }
+
+            return {
+                'roads_gdf': roads_gdf,
+                'landuse_gdf': landuse_gdf,
+                'facilities_gdf': facilities_gdf,
+                'subway_stations': subway_stations,
+                'bus_stops': bus_stops,
+                'entry_points': entry_points,
+                'context_summary': context_summary,
+            }
+        except Exception:
+            return {
+                'roads_gdf': _empty_gdf(),
+                'landuse_gdf': _empty_gdf(),
+                'facilities_gdf': _empty_gdf(),
+                'subway_stations': [],
+                'bus_stops': [],
+                'entry_points': [],
+                'context_summary': {},
+            }
+
+    def _boundary_to_bbox(
+        self,
+        boundary_geojson: dict,
+        buffer_m: float
+    ) -> tuple:
+        """
+        반환: (south, west, north, east) WGS84
+        """
+        geom = shape(boundary_geojson)
+        # Convert to EPSG:5179 for buffer in meters
+        coords = list(geom.exterior.coords)
+        transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+        poly_5179 = Polygon(transformed)
+        buffered_5179 = poly_5179.buffer(buffer_m)
+        # Convert back to WGS84
+        buf_coords = list(buffered_5179.exterior.coords)
+        wgs84_coords = [transformer_to_wgs84.transform(x, y) for x, y in buf_coords]
+        lons = [c[0] for c in wgs84_coords]
+        lats = [c[1] for c in wgs84_coords]
+        return (min(lats), min(lons), max(lats), max(lons))
+
+    def _fetch_osm(
+        self,
+        bbox: tuple,
+        timeout: int = 25
+    ) -> dict:
+        """
+        Overpass API 호출
+        실패/타임아웃시 빈 dict 반환
+        """
+        try:
+            south, west, north, east = bbox
+            overpass_url = "https://overpass-api.de/api/interpreter"
+            query = f"""
+[out:json][timeout:{timeout}];
+(
+  way["highway"]({south},{west},{north},{east});
+  way["landuse"]({south},{west},{north},{east});
+  way["building"]({south},{west},{north},{east});
+  node["railway"="station"]({south},{west},{north},{east});
+  node["railway"="subway_entrance"]({south},{west},{north},{east});
+  node["subway"="yes"]({south},{west},{north},{east});
+  node["highway"="bus_stop"]({south},{west},{north},{east});
+  way["leisure"="park"]({south},{west},{north},{east});
+  way["amenity"]({south},{west},{north},{east});
+  node["amenity"]({south},{west},{north},{east});
+);
+out body;
+>;
+out skel qt;
+"""
+            response = requests.post(
+                overpass_url,
+                data={'data': query},
+                timeout=timeout
+            )
+            if response.status_code == 200:
+                return response.json()
+            return {}
+        except Exception:
+            return {}
+
+    def _parse_roads(self, osm_data: dict) -> gpd.GeoDataFrame:
+        """OSM 데이터에서 도로 추출"""
+        try:
+            if not osm_data or 'elements' not in osm_data:
+                return _empty_gdf()
+
+            nodes = {e['id']: e for e in osm_data['elements'] if e['type'] == 'node'}
+            roads = []
+
+            highway_width_map = {
+                'motorway': 30, 'trunk': 25, 'primary': 20,
+                'secondary': 15, 'tertiary': 12, 'residential': 8,
+                'service': 6, 'unclassified': 8, 'living_street': 6,
+                'footway': 3, 'cycleway': 3, 'path': 3,
+            }
+
+            for elem in osm_data['elements']:
+                if elem['type'] != 'way':
+                    continue
+                tags = elem.get('tags', {})
+                highway = tags.get('highway')
+                if not highway:
+                    continue
+
+                node_ids = elem.get('nodes', [])
+                coords = []
+                for nid in node_ids:
+                    if nid in nodes:
+                        n = nodes[nid]
+                        coords.append((n['lon'], n['lat']))
+
+                if len(coords) < 2:
+                    continue
+
+                x_coords = [transformer_to_5179.transform(lon, lat)[0] for lon, lat in coords]
+                y_coords = [transformer_to_5179.transform(lon, lat)[1] for lon, lat in coords]
+                line = LineString(zip(x_coords, y_coords))
+
+                width_m = highway_width_map.get(highway, 8)
+                try:
+                    width_tag = float(tags.get('width', 0))
+                    if width_tag > 0:
+                        width_m = width_tag
+                except (ValueError, TypeError):
+                    pass
+
+                roads.append({
+                    'geometry': line,
+                    'highway': highway,
+                    'name': tags.get('name', tags.get('name:ko', '')),
+                    'width_m': width_m,
+                    'osm_id': elem['id'],
+                })
+
+            if not roads:
+                return _empty_gdf()
+
+            gdf = gpd.GeoDataFrame(roads, crs=f"EPSG:{EPSG_5179}")
+            return gdf
+        except Exception:
+            return _empty_gdf()
+
+    def _parse_landuse(self, osm_data: dict) -> gpd.GeoDataFrame:
+        """OSM 데이터에서 토지이용 추출"""
+        try:
+            if not osm_data or 'elements' not in osm_data:
+                return _empty_gdf()
+
+            nodes = {e['id']: e for e in osm_data['elements'] if e['type'] == 'node'}
+            landuses = []
+
+            for elem in osm_data['elements']:
+                if elem['type'] != 'way':
+                    continue
+                tags = elem.get('tags', {})
+                landuse = tags.get('landuse') or tags.get('leisure') or tags.get('amenity')
+                if not landuse:
+                    continue
+
+                node_ids = elem.get('nodes', [])
+                coords = []
+                for nid in node_ids:
+                    if nid in nodes:
+                        n = nodes[nid]
+                        coords.append((n['lon'], n['lat']))
+
+                if len(coords) < 3:
+                    continue
+
+                x_coords = [transformer_to_5179.transform(lon, lat)[0] for lon, lat in coords]
+                y_coords = [transformer_to_5179.transform(lon, lat)[1] for lon, lat in coords]
+                poly = Polygon(zip(x_coords, y_coords))
+                if not poly.is_valid:
+                    poly = poly.buffer(0)
+
+                landuses.append({
+                    'geometry': poly,
+                    'landuse': landuse,
+                    'name': tags.get('name', tags.get('name:ko', '')),
+                    'osm_id': elem['id'],
+                })
+
+            if not landuses:
+                return _empty_gdf()
+
+            gdf = gpd.GeoDataFrame(landuses, crs=f"EPSG:{EPSG_5179}")
+            return gdf
+        except Exception:
+            return _empty_gdf()
+
+    def _parse_facilities(self, osm_data: dict) -> gpd.GeoDataFrame:
+        """OSM 데이터에서 시설 추출"""
+        try:
+            if not osm_data or 'elements' not in osm_data:
+                return _empty_gdf()
+
+            nodes = {e['id']: e for e in osm_data['elements'] if e['type'] == 'node'}
+            facilities = []
+
+            facility_tags = ['school', 'hospital', 'library', 'community_centre',
+                             'police', 'fire_station', 'post_office', 'bank']
+
+            for elem in osm_data['elements']:
+                tags = elem.get('tags', {})
+                amenity = tags.get('amenity', '')
+
+                if elem['type'] == 'node' and amenity in facility_tags:
+                    lon, lat = elem.get('lon', 0), elem.get('lat', 0)
+                    x, y = transformer_to_5179.transform(lon, lat)
+                    # Create small square polygon (50m x 50m) for node facilities
+                    pt = Point(x, y)
+                    poly = pt.buffer(25, cap_style=3)  # square buffer
+                    facilities.append({
+                        'geometry': poly,
+                        'facility_type': amenity,
+                        'name': tags.get('name', tags.get('name:ko', '')),
+                    })
+                elif elem['type'] == 'way' and amenity in facility_tags:
+                    node_ids = elem.get('nodes', [])
+                    coords = []
+                    for nid in node_ids:
+                        if nid in nodes:
+                            n = nodes[nid]
+                            coords.append((n['lon'], n['lat']))
+                    if len(coords) >= 3:
+                        x_coords = [transformer_to_5179.transform(lon, lat)[0] for lon, lat in coords]
+                        y_coords = [transformer_to_5179.transform(lon, lat)[1] for lon, lat in coords]
+                        poly = Polygon(zip(x_coords, y_coords))
+                        if not poly.is_valid:
+                            poly = poly.buffer(0)
+                        facilities.append({
+                            'geometry': poly,
+                            'facility_type': amenity,
+                            'name': tags.get('name', tags.get('name:ko', '')),
+                        })
+
+            if not facilities:
+                return _empty_gdf()
+
+            gdf = gpd.GeoDataFrame(facilities, crs=f"EPSG:{EPSG_5179}")
+            return gdf
+        except Exception:
+            return _empty_gdf()
+
+    def _parse_subway_stations(self, osm_data: dict) -> list:
+        """지하철역 파싱"""
+        try:
+            if not osm_data or 'elements' not in osm_data:
+                return []
+
+            stations = []
+            for elem in osm_data['elements']:
+                if elem['type'] != 'node':
+                    continue
+                tags = elem.get('tags', {})
+                railway = tags.get('railway', '')
+                subway = tags.get('subway', '')
+
+                if railway in ('station', 'subway_entrance') or subway == 'yes':
+                    lon, lat = elem.get('lon', 0), elem.get('lat', 0)
+                    x, y = transformer_to_5179.transform(lon, lat)
+                    stations.append({
+                        'name': tags.get('name', tags.get('name:ko', '지하철역')),
+                        'lon': lon,
+                        'lat': lat,
+                        'x': x,
+                        'y': y,
+                        'line': tags.get('line', ''),
+                    })
+            return stations
+        except Exception:
+            return []
+
+    def _parse_bus_stops(self, osm_data: dict) -> list:
+        """버스 정류장 파싱"""
+        try:
+            if not osm_data or 'elements' not in osm_data:
+                return []
+
+            stops = []
+            for elem in osm_data['elements']:
+                if elem['type'] != 'node':
+                    continue
+                tags = elem.get('tags', {})
+                if tags.get('highway') == 'bus_stop':
+                    lon, lat = elem.get('lon', 0), elem.get('lat', 0)
+                    x, y = transformer_to_5179.transform(lon, lat)
+                    stops.append({
+                        'name': tags.get('name', tags.get('name:ko', '버스정류장')),
+                        'lon': lon,
+                        'lat': lat,
+                        'x': x,
+                        'y': y,
+                    })
+            return stops
+        except Exception:
+            return []
+
+    def get_entry_points(
+        self,
+        boundary_geojson: dict,
+        roads_gdf: gpd.GeoDataFrame
+    ) -> list:
+        """
+        대상지 경계와 교차하는 기존 도로 탐색
+        반환:
+        [
+          {
+            'point': (x, y),        # EPSG:5179
+            'point_wgs84': (lon,lat),
+            'road_name': str,
+            'road_width_m': float,
+            'road_type': str,
+            'angle_deg': float
+          }
+        ]
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            boundary_5179 = Polygon(transformed)
+            boundary_line = boundary_5179.exterior
+
+            if roads_gdf.empty:
+                return []
+
+            entry_points = []
+
+            for idx, row in roads_gdf.iterrows():
+                road_geom = row.geometry
+                if road_geom is None:
+                    continue
+
+                intersection = boundary_line.intersection(road_geom)
+                if intersection.is_empty:
+                    continue
+
+                pts = []
+                if intersection.geom_type == 'Point':
+                    pts = [intersection]
+                elif intersection.geom_type == 'MultiPoint':
+                    pts = list(intersection.geoms)
+                elif intersection.geom_type == 'LineString':
+                    centroid = intersection.centroid
+                    pts = [centroid]
+                elif intersection.geom_type == 'GeometryCollection':
+                    for g in intersection.geoms:
+                        if g.geom_type == 'Point':
+                            pts.append(g)
+                        elif g.geom_type == 'LineString':
+                            pts.append(g.centroid)
+
+                for pt in pts:
+                    x, y = pt.x, pt.y
+                    lon, lat = transformer_to_wgs84.transform(x, y)
+
+                    # Compute angle from road direction at intersection
+                    angle_deg = 0.0
+                    try:
+                        if isinstance(road_geom, LineString):
+                            coords_road = list(road_geom.coords)
+                            if len(coords_road) >= 2:
+                                dx = coords_road[-1][0] - coords_road[0][0]
+                                dy = coords_road[-1][1] - coords_road[0][1]
+                                angle_deg = math.degrees(math.atan2(dy, dx)) % 360
+                    except Exception:
+                        pass
+
+                    highway = row.get('highway', 'unclassified')
+                    entry_points.append({
+                        'point': (x, y),
+                        'point_wgs84': (lon, lat),
+                        'road_name': row.get('name', ''),
+                        'road_width_m': float(row.get('width_m', 8)),
+                        'road_type': highway,
+                        'angle_deg': angle_deg,
+                    })
+
+            # Deduplicate nearby entry points (within 20m)
+            deduplicated = []
+            for ep in entry_points:
+                px, py = ep['point']
+                too_close = False
+                for dep in deduplicated:
+                    dx, dy = dep['point']
+                    if math.hypot(px - dx, py - dy) < 20:
+                        too_close = True
+                        break
+                if not too_close:
+                    deduplicated.append(ep)
+
+            return deduplicated
+
+        except Exception:
+            return []
+
+    def analyze_surroundings(
+        self,
+        boundary_geojson: dict,
+        roads_gdf: gpd.GeoDataFrame,
+        landuse_gdf: gpd.GeoDataFrame,
+        facilities_gdf: gpd.GeoDataFrame,
+        subway_stations: list,
+    ) -> dict:
+        """
+        반환:
+        {
+          'adjacent_use_north': str,
+          'adjacent_use_south': str,
+          'adjacent_use_east': str,
+          'adjacent_use_west': str,
+          'nearest_subway_m': float,
+          'nearest_subway_name': str,
+          'is_tod_zone': bool,        # 역세권 500m 이내
+          'avg_building_height_m': float,
+          'dominant_surrounding_use': str,
+          'recommendations': list[str]
+        }
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            boundary_5179 = Polygon(transformed)
+            centroid = boundary_5179.centroid
+            cx, cy = centroid.x, centroid.y
+
+            # Analyze adjacent uses by quadrant
+            def get_direction_use(direction: str) -> str:
+                if landuse_gdf.empty:
+                    return '미확인'
+                offset = 200  # 200m offset in direction
+                if direction == 'north':
+                    probe = Point(cx, cy + offset)
+                elif direction == 'south':
+                    probe = Point(cx, cy - offset)
+                elif direction == 'east':
+                    probe = Point(cx + offset, cy)
+                else:  # west
+                    probe = Point(cx - offset, cy)
+
+                min_dist = float('inf')
+                closest_use = '미확인'
+                for idx, row in landuse_gdf.iterrows():
+                    d = probe.distance(row.geometry)
+                    if d < min_dist:
+                        min_dist = d
+                        lu = row.get('landuse', '미확인')
+                        closest_use = _translate_landuse(lu)
+                return closest_use
+
+            adjacent_north = get_direction_use('north')
+            adjacent_south = get_direction_use('south')
+            adjacent_east = get_direction_use('east')
+            adjacent_west = get_direction_use('west')
+
+            # Nearest subway
+            nearest_subway_m = float('inf')
+            nearest_subway_name = '없음'
+            for station in subway_stations:
+                sx, sy = station['x'], station['y']
+                dist = math.hypot(cx - sx, cy - sy)
+                if dist < nearest_subway_m:
+                    nearest_subway_m = dist
+                    nearest_subway_name = station['name']
+
+            if nearest_subway_m == float('inf'):
+                nearest_subway_m = 9999.0
+
+            is_tod_zone = nearest_subway_m <= 500
+
+            # Dominant surrounding use
+            uses = [adjacent_north, adjacent_south, adjacent_east, adjacent_west]
+            use_counts = {}
+            for u in uses:
+                if u != '미확인':
+                    use_counts[u] = use_counts.get(u, 0) + 1
+            dominant = max(use_counts, key=use_counts.get) if use_counts else '미확인'
+
+            # Recommendations
+            recommendations = []
+            if is_tod_zone:
+                recommendations.append(f"역세권({nearest_subway_name} {nearest_subway_m:.0f}m): 고밀 복합개발 권장")
+            if dominant == '주거':
+                recommendations.append("주변 주거지역 연속성 확보: 중저층 주거지역 배치 권장")
+            elif dominant == '상업':
+                recommendations.append("주변 상업지역 연계: 근린상업 또는 일반상업 배치 권장")
+            if adjacent_north == '주거':
+                recommendations.append("북측 주거지역 일조 고려: 북측 저층화 필요")
+
+            return {
+                'adjacent_use_north': adjacent_north,
+                'adjacent_use_south': adjacent_south,
+                'adjacent_use_east': adjacent_east,
+                'adjacent_use_west': adjacent_west,
+                'nearest_subway_m': round(nearest_subway_m, 1),
+                'nearest_subway_name': nearest_subway_name,
+                'is_tod_zone': is_tod_zone,
+                'avg_building_height_m': 15.0,  # Default estimate
+                'dominant_surrounding_use': dominant,
+                'recommendations': recommendations,
+            }
+
+        except Exception:
+            return {
+                'adjacent_use_north': '미확인',
+                'adjacent_use_south': '미확인',
+                'adjacent_use_east': '미확인',
+                'adjacent_use_west': '미확인',
+                'nearest_subway_m': 9999.0,
+                'nearest_subway_name': '없음',
+                'is_tod_zone': False,
+                'avg_building_height_m': 15.0,
+                'dominant_surrounding_use': '미확인',
+                'recommendations': [],
+            }
+
+
+def _translate_landuse(osm_landuse: str) -> str:
+    """OSM landuse → 한국어 용도"""
+    mapping = {
+        'residential': '주거',
+        'commercial': '상업',
+        'retail': '상업',
+        'industrial': '공업',
+        'farmland': '농지',
+        'forest': '임야',
+        'grass': '녹지',
+        'park': '공원',
+        'recreation_ground': '공원',
+        'school': '학교',
+        'hospital': '의료',
+        'government': '공공',
+        'military': '군사',
+        'cemetery': '묘지',
+        'construction': '개발중',
+        'brownfield': '나대지',
+        'greenfield': '녹지',
+    }
+    return mapping.get(osm_landuse, osm_landuse if osm_landuse else '미확인')

--- a/urban_planner/engine/facility_placer.py
+++ b/urban_planner/engine/facility_placer.py
@@ -1,0 +1,397 @@
+"""
+공공시설 배치 모듈
+절대 규칙: Circle/Point 사용 금지, 모든 시설은 블록 Polygon 그대로 사용
+"""
+
+import json
+import math
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import Point, Polygon
+from shapely.ops import unary_union
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_wgs84 = Transformer.from_crs(EPSG_5179, EPSG_WGS84, always_xy=True)
+
+FACILITY_COLORS = {
+    'neighborhood_park': '#2ECC71',    # 근린공원 - 초록
+    'children_park': '#27AE60',        # 어린이공원 - 진초록
+    'elementary_school': '#3498DB',    # 초등학교 - 파랑
+    'middle_school': '#2980B9',        # 중학교 - 진파랑
+    'high_school': '#1ABC9C',          # 고등학교 - 청록
+    'community_center': '#E74C3C',     # 주민센터 - 빨강
+    'welfare_center': '#E67E22',       # 복지관 - 주황
+    'park': '#2ECC71',
+}
+
+FACILITY_NAMES = {
+    'neighborhood_park': '근린공원',
+    'children_park': '어린이공원',
+    'elementary_school': '초등학교',
+    'middle_school': '중학교',
+    'high_school': '고등학교',
+    'community_center': '주민센터',
+    'welfare_center': '복지관',
+}
+
+
+class FacilityPlacer:
+
+    def place(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        design_params: dict,
+        context: dict
+    ) -> dict:
+        """
+        공공시설 배치
+
+        반환:
+        {
+          'facilities_gdf': GeoDataFrame,
+          'facilities_geojson': dict,
+          'coverage': {
+            'park_250m_ratio': float,
+            'park_500m_ratio': float,
+            'school_500m_ratio': float
+          }
+        }
+
+        절대 규칙:
+        - Circle/Point 사용 금지
+        - 모든 시설은 블록 Polygon 그대로 사용
+        - 블록에 facility_type 속성 추가
+        """
+        try:
+            if blocks_gdf.empty:
+                return self._empty_result()
+
+            target_population = design_params.get('target_population', 0)
+            area_ha = blocks_gdf.geometry.area.sum() / 10000
+
+            # Estimate population if not given
+            if target_population <= 0:
+                # Rough estimate: 150 persons/ha for mixed development
+                target_population = int(area_ha * 150)
+
+            # Estimate households (avg 2.5 persons/household)
+            estimated_households = max(100, int(target_population / 2.5))
+
+            facility_rows = []
+
+            # 1. Select park blocks
+            nbhd_parks = self._select_park_blocks(blocks_gdf, 'neighborhood')
+            for idx, row in nbhd_parks.iterrows():
+                facility_rows.append({
+                    'geometry': row.geometry,
+                    'facility_type': 'neighborhood_park',
+                    'facility_name': '근린공원',
+                    'area_m2': row.geometry.area,
+                    'color': FACILITY_COLORS['neighborhood_park'],
+                })
+
+            child_parks = self._select_park_blocks(blocks_gdf, 'children')
+            for idx, row in child_parks.iterrows():
+                facility_rows.append({
+                    'geometry': row.geometry,
+                    'facility_type': 'children_park',
+                    'facility_name': '어린이공원',
+                    'area_m2': row.geometry.area,
+                    'color': FACILITY_COLORS['children_park'],
+                })
+
+            # 2. Select school blocks
+            school_blocks = self._select_school_blocks(blocks_gdf, estimated_households)
+            for idx, row in school_blocks.iterrows():
+                school_type = row.get('_school_type', 'elementary_school')
+                facility_rows.append({
+                    'geometry': row.geometry,
+                    'facility_type': school_type,
+                    'facility_name': FACILITY_NAMES.get(school_type, '학교'),
+                    'area_m2': row.geometry.area,
+                    'color': FACILITY_COLORS.get(school_type, '#3498DB'),
+                })
+
+            # 3. Community facilities (주민센터, 복지관)
+            if estimated_households >= 500:
+                community_blocks = self._select_community_blocks(blocks_gdf, estimated_households)
+                for idx, row in community_blocks.iterrows():
+                    ftype = row.get('_facility_type', 'community_center')
+                    facility_rows.append({
+                        'geometry': row.geometry,
+                        'facility_type': ftype,
+                        'facility_name': FACILITY_NAMES.get(ftype, '공공시설'),
+                        'area_m2': row.geometry.area,
+                        'color': FACILITY_COLORS.get(ftype, '#E74C3C'),
+                    })
+
+            if not facility_rows:
+                return self._empty_result()
+
+            facilities_gdf = gpd.GeoDataFrame(facility_rows, crs=f"EPSG:{EPSG_5179}")
+
+            # Calculate coverage
+            coverage = self._calculate_coverage(
+                blocks_gdf, facilities_gdf, target_population
+            )
+
+            # Convert to WGS84 GeoJSON
+            facilities_wgs84 = facilities_gdf.to_crs(EPSG_WGS84)
+            facilities_geojson = json.loads(facilities_wgs84.to_json())
+
+            return {
+                'facilities_gdf': facilities_gdf,
+                'facilities_geojson': facilities_geojson,
+                'coverage': coverage,
+            }
+
+        except Exception as e:
+            return self._empty_result()
+
+    def _select_park_blocks(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        park_type: str  # 'neighborhood'|'children'
+    ) -> gpd.GeoDataFrame:
+        """
+        공원으로 지정할 블록 선택
+        neighborhood: 10,000m² 이상 블록 또는 인접블록 합치기
+        children: 1,500~5,000m² 주거인접 블록
+        """
+        try:
+            if park_type == 'neighborhood':
+                # Large blocks for neighborhood park
+                candidates = blocks_gdf[blocks_gdf['area_m2'] >= 8000].copy()
+                if candidates.empty:
+                    # Use largest block
+                    largest = blocks_gdf.nlargest(1, 'area_m2')
+                    return largest
+                # Select 1-2 blocks
+                selected = candidates.nlargest(min(2, len(candidates)), 'area_m2')
+                return selected
+
+            else:  # children
+                # Small to medium blocks for children's park
+                candidates = blocks_gdf[
+                    (blocks_gdf['area_m2'] >= 1500) &
+                    (blocks_gdf['area_m2'] <= 6000)
+                ].copy()
+
+                if candidates.empty:
+                    return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+                # Prefer blocks near residential areas
+                # Select up to 2 blocks spread out spatially
+                if len(candidates) <= 2:
+                    return candidates
+
+                # Select blocks that are spatially separated
+                selected = []
+                remaining = candidates.copy()
+                while len(selected) < 3 and not remaining.empty:
+                    # Pick the one with smallest area (appropriate for children's park)
+                    pick = remaining.nsmallest(1, 'area_m2').iloc[0]
+                    pick_geom = pick.geometry
+                    selected.append(pick.name)
+
+                    # Remove nearby blocks (within 200m)
+                    centroid = pick_geom.centroid
+                    remaining = remaining[
+                        remaining.geometry.centroid.distance(centroid) > 200
+                    ]
+
+                return candidates.loc[selected]
+
+        except Exception:
+            return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+    def _select_school_blocks(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        estimated_households: int
+    ) -> gpd.GeoDataFrame:
+        """
+        학교 블록 선택
+        초등: 500세대당 1개, 5,000~10,000m²
+        중학: 2,000세대당 1개, 8,000~15,000m²
+        """
+        try:
+            selected_rows = []
+
+            # Elementary schools
+            n_elementary = max(1, estimated_households // 500)
+            n_elementary = min(n_elementary, 3)  # max 3
+
+            elem_candidates = blocks_gdf[
+                (blocks_gdf['area_m2'] >= 4000) &
+                (blocks_gdf['area_m2'] <= 12000)
+            ].copy()
+
+            if not elem_candidates.empty:
+                elem_selected = elem_candidates.nlargest(
+                    min(n_elementary, len(elem_candidates)), 'area_m2'
+                )
+                for idx, row in elem_selected.iterrows():
+                    row_dict = row.to_dict()
+                    row_dict['_school_type'] = 'elementary_school'
+                    selected_rows.append(row_dict)
+
+            # Middle schools
+            n_middle = max(0, estimated_households // 2000)
+            n_middle = min(n_middle, 2)  # max 2
+
+            if n_middle > 0:
+                # Exclude already selected
+                selected_indices = [r.get('_orig_idx') for r in selected_rows]
+                middle_candidates = blocks_gdf[
+                    (blocks_gdf['area_m2'] >= 8000) &
+                    (blocks_gdf['area_m2'] <= 15000)
+                ].copy()
+
+                if not middle_candidates.empty:
+                    # Select blocks not already used
+                    available = middle_candidates[
+                        ~middle_candidates.index.isin([
+                            r for r in selected_rows
+                        ])
+                    ]
+                    if available.empty:
+                        available = middle_candidates
+
+                    mid_selected = available.nlargest(
+                        min(n_middle, len(available)), 'area_m2'
+                    )
+                    for idx, row in mid_selected.iterrows():
+                        row_dict = row.to_dict()
+                        row_dict['_school_type'] = 'middle_school'
+                        selected_rows.append(row_dict)
+
+            if not selected_rows:
+                return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+            result_gdf = gpd.GeoDataFrame(selected_rows, crs=f"EPSG:{EPSG_5179}")
+            return result_gdf
+
+        except Exception:
+            return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+    def _select_community_blocks(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        estimated_households: int
+    ) -> gpd.GeoDataFrame:
+        """주민센터, 복지관 블록 선택"""
+        try:
+            selected_rows = []
+
+            # 주민센터: 2,000세대당 1개
+            n_community = max(1, estimated_households // 2000)
+            n_community = min(n_community, 2)
+
+            candidates = blocks_gdf[
+                (blocks_gdf['area_m2'] >= 1000) &
+                (blocks_gdf['area_m2'] <= 3000)
+            ].copy()
+
+            if candidates.empty:
+                candidates = blocks_gdf[
+                    blocks_gdf['area_m2'] < 5000
+                ].nsmallest(3, 'area_m2')
+
+            if not candidates.empty:
+                selected = candidates.nsmallest(
+                    min(n_community, len(candidates)), 'area_m2'
+                )
+                for idx, row in selected.iterrows():
+                    row_dict = row.to_dict()
+                    row_dict['_facility_type'] = 'community_center'
+                    selected_rows.append(row_dict)
+
+            # 복지관: 10,000명당 1개
+            if estimated_households * 2.5 >= 10000:
+                welfare_candidates = blocks_gdf[
+                    (blocks_gdf['area_m2'] >= 2000) &
+                    (blocks_gdf['area_m2'] <= 5000)
+                ].copy()
+
+                if not welfare_candidates.empty:
+                    welfare = welfare_candidates.nsmallest(1, 'area_m2')
+                    for idx, row in welfare.iterrows():
+                        row_dict = row.to_dict()
+                        row_dict['_facility_type'] = 'welfare_center'
+                        selected_rows.append(row_dict)
+
+            if not selected_rows:
+                return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+            return gpd.GeoDataFrame(selected_rows, crs=f"EPSG:{EPSG_5179}")
+
+        except Exception:
+            return gpd.GeoDataFrame(crs=f"EPSG:{EPSG_5179}")
+
+    def _calculate_coverage(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        facilities_gdf: gpd.GeoDataFrame,
+        target_population: int
+    ) -> dict:
+        """서비스 커버리지 계산"""
+        try:
+            if facilities_gdf.empty or blocks_gdf.empty:
+                return {
+                    'park_250m_ratio': 0.0,
+                    'park_500m_ratio': 0.0,
+                    'school_500m_ratio': 0.0,
+                }
+
+            total_area = blocks_gdf.geometry.area.sum()
+
+            park_types = ['neighborhood_park', 'children_park']
+            park_mask = facilities_gdf['facility_type'].isin(park_types)
+            parks_gdf = facilities_gdf[park_mask]
+
+            school_types = ['elementary_school', 'middle_school']
+            school_mask = facilities_gdf['facility_type'].isin(school_types)
+            schools_gdf = facilities_gdf[school_mask]
+
+            def calc_coverage(service_gdf, radius_m):
+                if service_gdf.empty:
+                    return 0.0
+                service_zones = service_gdf.geometry.buffer(radius_m)
+                union_zone = unary_union(service_zones)
+                covered = blocks_gdf.geometry.intersection(union_zone).area.sum()
+                return round(float(covered) / float(total_area), 4) if total_area > 0 else 0.0
+
+            park_250 = calc_coverage(parks_gdf, 250)
+            park_500 = calc_coverage(parks_gdf, 500)
+            school_500 = calc_coverage(schools_gdf, 500)
+
+            return {
+                'park_250m_ratio': park_250,
+                'park_500m_ratio': park_500,
+                'school_500m_ratio': school_500,
+            }
+        except Exception:
+            return {
+                'park_250m_ratio': 0.0,
+                'park_500m_ratio': 0.0,
+                'school_500m_ratio': 0.0,
+            }
+
+    def _empty_result(self) -> dict:
+        empty_gdf = gpd.GeoDataFrame(
+            columns=['geometry', 'facility_type', 'facility_name', 'area_m2', 'color'],
+            crs=f"EPSG:{EPSG_5179}"
+        )
+        return {
+            'facilities_gdf': empty_gdf,
+            'facilities_geojson': {'type': 'FeatureCollection', 'features': []},
+            'coverage': {
+                'park_250m_ratio': 0.0,
+                'park_500m_ratio': 0.0,
+                'school_500m_ratio': 0.0,
+            },
+        }

--- a/urban_planner/engine/master_planner.py
+++ b/urban_planner/engine/master_planner.py
@@ -1,0 +1,486 @@
+"""
+토지이용계획 수립 모듈 (용도지역 배치)
+"""
+
+import os
+import json
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import shape, Polygon
+from shapely.ops import unary_union
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# 용도 코드별 표준 정보
+ZONING_INFO = {
+    'R1': {'name': '제1종전용주거', 'far': 100, 'color': '#FFE4E1'},
+    'R2': {'name': '제2종전용주거', 'far': 120, 'color': '#FFCDD2'},
+    'R3': {'name': '제1종일반주거', 'far': 150, 'color': '#FFB3BA'},
+    'R4': {'name': '제2종일반주거', 'far': 200, 'color': '#FF8FAB'},
+    'R5': {'name': '제3종일반주거', 'far': 300, 'color': '#FF69B4'},
+    'RQ': {'name': '준주거', 'far': 500, 'color': '#DDA0DD'},
+    'CB': {'name': '중심상업', 'far': 1000, 'color': '#FF2400'},
+    'CG': {'name': '일반상업', 'far': 800, 'color': '#FF4500'},
+    'CN': {'name': '근린상업', 'far': 600, 'color': '#FF8C00'},
+    'IQ': {'name': '준공업', 'far': 400, 'color': '#A9A9A9'},
+    'GN': {'name': '자연녹지', 'far': 100, 'color': '#228B22'},
+    'PK': {'name': '공원', 'far': 0, 'color': '#90EE90'},
+    'PF': {'name': '공공시설', 'far': 200, 'color': '#4169E1'},
+    'ROAD': {'name': '도로', 'far': 0, 'color': '#CCCCCC'},
+}
+
+
+class MasterPlanner:
+
+    def plan(
+        self,
+        boundary_geojson: dict,
+        site_analysis: dict,
+        design_params: dict,
+        context_analysis: dict
+    ) -> dict:
+        """
+        반환:
+        {
+          'zoning_gdf': GeoDataFrame,    # 용도지역 Polygon들
+          'zoning_geojson': dict,        # WGS84 GeoJSON
+          'zoning_stats': dict,          # 용도별 면적/비율
+          'design_rationale': str        # 배치 근거 텍스트
+        }
+        """
+        try:
+            area_ha = site_analysis.get('area_ha', 10.0)
+            similar_cases = site_analysis.get('similar_cases', [])
+
+            # Calculate target zoning ratios
+            target_ratios = self._calculate_zoning_ratios(
+                area_ha, design_params, context_analysis, similar_cases
+            )
+
+            # Get blocks GDF from design_params (passed from block_divider)
+            # If blocks not available, create a simple division from boundary
+            blocks_gdf = design_params.get('_blocks_gdf', None)
+            if blocks_gdf is None or (hasattr(blocks_gdf, 'empty') and blocks_gdf.empty):
+                blocks_gdf = self._create_simple_blocks(boundary_geojson, area_ha)
+
+            # Assign zoning to blocks
+            zoning_gdf = self._assign_zoning_to_blocks(
+                blocks_gdf, target_ratios, context_analysis
+            )
+
+            # Smooth boundaries
+            zoning_gdf = self._smooth_zoning_boundaries(zoning_gdf)
+
+            # Calculate stats
+            total_area = zoning_gdf.geometry.area.sum()
+            zoning_stats = {}
+            for code in zoning_gdf['zone_code'].unique():
+                mask = zoning_gdf['zone_code'] == code
+                zone_area = zoning_gdf[mask].geometry.area.sum()
+                info = ZONING_INFO.get(code, {'name': code, 'far': 0})
+                zoning_stats[code] = {
+                    'name': info['name'],
+                    'area_m2': round(float(zone_area), 1),
+                    'area_ha': round(float(zone_area) / 10000, 3),
+                    'ratio': round(float(zone_area) / total_area, 4) if total_area > 0 else 0,
+                    'far_max': info.get('far', 0),
+                }
+
+            # Convert to WGS84 GeoJSON
+            zoning_wgs84 = zoning_gdf.to_crs(EPSG_WGS84)
+            zoning_geojson = json.loads(zoning_wgs84.to_json())
+
+            # Generate design rationale text
+            design_rationale = self._generate_rationale(
+                zoning_stats, context_analysis, design_params, similar_cases
+            )
+
+            return {
+                'zoning_gdf': zoning_gdf,
+                'zoning_geojson': zoning_geojson,
+                'zoning_stats': zoning_stats,
+                'design_rationale': design_rationale,
+            }
+
+        except Exception as e:
+            empty_gdf = gpd.GeoDataFrame(geometry=[], crs=f"EPSG:{EPSG_5179}")
+            return {
+                'zoning_gdf': empty_gdf,
+                'zoning_geojson': {'type': 'FeatureCollection', 'features': []},
+                'zoning_stats': {},
+                'design_rationale': f'계획 수립 중 오류 발생: {str(e)}',
+            }
+
+    def _calculate_zoning_ratios(
+        self,
+        area_ha: float,
+        design_params: dict,
+        context_analysis: dict,
+        similar_cases: list
+    ) -> dict:
+        """
+        용도별 목표 면적 비율 계산
+        반환: {'residential': 0.5, 'commercial': 0.1, ...}
+        """
+        program = design_params.get('program', '혼합용도')
+        green_ratio_min = design_params.get('green_ratio_min', 0.10)
+        road_ratio = design_params.get('road_ratio_target', 0.25)
+        is_tod = context_analysis.get('is_tod_zone', False)
+
+        # Priority weights
+        priority = design_params.get('priority', {})
+        density = priority.get('density', 3)
+        green = priority.get('green', 3)
+        publicfacility = priority.get('publicfacility', 3)
+
+        # Base ratios by program
+        if program == '주거중심':
+            base = {
+                'residential': 0.55,
+                'commercial': 0.06,
+                'green': 0.18,
+                'public': 0.09,
+                'road': road_ratio,
+            }
+        elif program == '상업중심':
+            base = {
+                'residential': 0.30,
+                'commercial': 0.22,
+                'green': 0.15,
+                'public': 0.08,
+                'road': road_ratio,
+            }
+        elif program == '자족도시':
+            base = {
+                'residential': 0.38,
+                'commercial': 0.10,
+                'industrial': 0.07,
+                'green': 0.20,
+                'public': 0.10,
+                'road': road_ratio,
+            }
+        else:  # 혼합용도 (default)
+            base = {
+                'residential': 0.45,
+                'commercial': 0.10,
+                'green': 0.18,
+                'public': 0.10,
+                'road': road_ratio,
+            }
+
+        # Adjust for TOD zone
+        if is_tod:
+            base['residential'] = min(base['residential'] + 0.05, 0.65)
+            base['commercial'] = min(base['commercial'] + 0.03, 0.25)
+
+        # Adjust for green priority
+        green_adj = (green - 3) * 0.02
+        base['green'] = max(green_ratio_min, base['green'] + green_adj)
+
+        # Adjust for public facility priority
+        pf_adj = (publicfacility - 3) * 0.01
+        base['public'] = max(0.05, base.get('public', 0.08) + pf_adj)
+
+        # Adjust for density priority (affects residential type mix later)
+        # Higher density → more R4/R5/RQ
+
+        # Normalize to sum to 1.0 (excluding road which is fixed)
+        non_road_sum = sum(v for k, v in base.items() if k != 'road')
+        if non_road_sum > 0:
+            scale = (1.0 - base['road']) / non_road_sum
+            for k in list(base.keys()):
+                if k != 'road':
+                    base[k] = base[k] * scale
+
+        # Incorporate similar cases (weighted average)
+        if similar_cases:
+            best_case = similar_cases[0]
+            sim_score = best_case.get('similarity_score', 0)
+            if sim_score > 0.5:
+                case_mix = best_case.get('zoning_mix', {})
+                blend = sim_score * 0.3  # up to 30% blend with best case
+                if 'residential' in case_mix:
+                    base['residential'] = (1 - blend) * base.get('residential', 0.45) + blend * case_mix['residential']
+                if 'commercial' in case_mix:
+                    base['commercial'] = (1 - blend) * base.get('commercial', 0.10) + blend * case_mix['commercial']
+                if 'green' in case_mix:
+                    green_from_case = case_mix['green']
+                    base['green'] = max(green_ratio_min, (1 - blend) * base.get('green', 0.18) + blend * green_from_case)
+
+        return base
+
+    def _assign_zoning_to_blocks(
+        self,
+        blocks_gdf: gpd.GeoDataFrame,
+        target_ratios: dict,
+        context_analysis: dict
+    ) -> gpd.GeoDataFrame:
+        """
+        각 블록에 용도지역 코드 부여
+        """
+        if blocks_gdf.empty:
+            return gpd.GeoDataFrame(
+                columns=['geometry', 'zone_code', 'zone_name', 'area_m2'],
+                crs=f"EPSG:{EPSG_5179}"
+            )
+
+        gdf = blocks_gdf.copy()
+        total_area = gdf.geometry.area.sum()
+        is_tod = context_analysis.get('is_tod_zone', False)
+        nearest_subway_m = context_analysis.get('nearest_subway_m', 9999)
+
+        # Sort blocks by centroid Y (north = high Y in EPSG:5179)
+        gdf['_cy'] = gdf.geometry.centroid.y
+        gdf['_cx'] = gdf.geometry.centroid.x
+        gdf['_area'] = gdf.geometry.area
+
+        max_cy = gdf['_cy'].max()
+        min_cy = gdf['_cy'].min()
+        max_cx = gdf['_cx'].max()
+        min_cx = gdf['_cx'].min()
+        cy_range = max(max_cy - min_cy, 1)
+        cx_range = max(max_cx - min_cx, 1)
+
+        # Centroid coordinates
+        centroid_x = gdf['_cx'].mean()
+        centroid_y = gdf['_cy'].mean()
+
+        def assign_zone(row):
+            cy = row['_cy']
+            cx = row['_cx']
+            area = row['_area']
+            adj_road_w = row.get('adjacent_road_width_m', 0)
+            is_corner = row.get('is_corner', False)
+
+            # Normalized positions
+            north_ratio = (cy - min_cy) / cy_range  # 0=south, 1=north
+            east_ratio = (cx - min_cx) / cx_range   # 0=west, 1=east
+
+            # Distance from site centroid
+            dist_from_center = ((cx - centroid_x)**2 + (cy - centroid_y)**2)**0.5
+
+            # Rule 1: Widest road frontage → commercial
+            if adj_road_w >= 20 and is_corner:
+                return 'CB'  # 중심상업
+            if adj_road_w >= 15:
+                return 'CG'  # 일반상업
+            if adj_road_w >= 12:
+                return 'CN'  # 근린상업
+
+            # Rule 2: TOD zone → high-density residential
+            if is_tod and nearest_subway_m < 300:
+                return 'RQ'  # 준주거
+            if is_tod and nearest_subway_m < 500:
+                return 'R5'  # 제3종일반주거
+
+            # Rule 3: North blocks → residential (일조)
+            if north_ratio > 0.75:
+                if area > 8000:
+                    return 'R4'
+                return 'R3'
+
+            # Rule 4: Central large blocks
+            if area > 12000 and dist_from_center < cy_range * 0.3:
+                return 'R5'
+
+            # Rule 5: Small blocks near periphery
+            if area < 3000:
+                return 'CN'
+
+            # Default: second/third general residential
+            if north_ratio > 0.5:
+                return 'R3'
+            else:
+                return 'R4'
+
+        gdf['zone_code'] = gdf.apply(assign_zone, axis=1)
+
+        # Now enforce target ratios by adjusting assignments
+        gdf = self._enforce_target_ratios(gdf, target_ratios, total_area, is_tod)
+
+        gdf['zone_name'] = gdf['zone_code'].map(
+            lambda c: ZONING_INFO.get(c, {}).get('name', c)
+        )
+        gdf['area_m2'] = gdf.geometry.area
+
+        return gdf[['geometry', 'zone_code', 'zone_name', 'area_m2']].copy()
+
+    def _enforce_target_ratios(
+        self,
+        gdf: gpd.GeoDataFrame,
+        target_ratios: dict,
+        total_area: float,
+        is_tod: bool
+    ) -> gpd.GeoDataFrame:
+        """목표 비율에 맞게 용도 조정"""
+        target_residential = target_ratios.get('residential', 0.45) * total_area
+        target_commercial = target_ratios.get('commercial', 0.10) * total_area
+        target_green = target_ratios.get('green', 0.18) * total_area
+        target_public = target_ratios.get('public', 0.10) * total_area
+
+        # Current assigned areas
+        def get_area(codes):
+            mask = gdf['zone_code'].isin(codes)
+            return gdf[mask].geometry.area.sum()
+
+        residential_codes = ['R1', 'R2', 'R3', 'R4', 'R5', 'RQ']
+        commercial_codes = ['CB', 'CG', 'CN']
+
+        curr_res = get_area(residential_codes)
+        curr_com = get_area(commercial_codes)
+
+        # If commercial is too high, convert some to residential
+        if curr_com > target_commercial * 1.3:
+            cn_idx = gdf[gdf['zone_code'] == 'CN'].sort_values('_area').index
+            com_excess = curr_com - target_commercial
+            cum = 0
+            for idx in cn_idx:
+                if cum >= com_excess:
+                    break
+                gdf.loc[idx, 'zone_code'] = 'R4'
+                cum += gdf.loc[idx, '_area']
+
+        # Assign green space (largest park-suitable blocks)
+        green_needed = target_green
+        if green_needed > 0:
+            # Pick largest blocks that are currently R3 or R4 for green
+            candidates = gdf[gdf['zone_code'].isin(['R3', 'R4', 'R5'])].sort_values(
+                '_area', ascending=False
+            )
+            cum_green = 0
+            green_target_area = min(green_needed, total_area * 0.25)
+            for idx, row in candidates.iterrows():
+                if cum_green >= green_target_area:
+                    break
+                # Pick a few large blocks for parks
+                if row['_area'] > 3000 and cum_green < green_target_area * 0.5:
+                    gdf.loc[idx, 'zone_code'] = 'GN'
+                    cum_green += row['_area']
+
+        # Assign public facilities
+        pf_needed = target_public
+        if pf_needed > 0:
+            pf_candidates = gdf[gdf['zone_code'].isin(['R3', 'R4'])].sort_values('_area')
+            cum_pf = 0
+            for idx, row in pf_candidates.iterrows():
+                if cum_pf >= pf_needed:
+                    break
+                if 2000 <= row['_area'] <= 10000:
+                    gdf.loc[idx, 'zone_code'] = 'PF'
+                    cum_pf += row['_area']
+
+        return gdf
+
+    def _smooth_zoning_boundaries(
+        self,
+        zoning_gdf: gpd.GeoDataFrame
+    ) -> gpd.GeoDataFrame:
+        """
+        동일 용도 인접 블록 합치기 (dissolve)
+        경계선 simplify(tolerance=1.5m)
+        """
+        try:
+            if zoning_gdf.empty:
+                return zoning_gdf
+
+            dissolved = zoning_gdf.dissolve(by='zone_code', aggfunc='first').reset_index()
+            dissolved['geometry'] = dissolved['geometry'].simplify(tolerance=1.5, preserve_topology=True)
+            dissolved['area_m2'] = dissolved.geometry.area
+            dissolved['zone_name'] = dissolved['zone_code'].map(
+                lambda c: ZONING_INFO.get(c, {}).get('name', c)
+            )
+            return dissolved
+        except Exception:
+            return zoning_gdf
+
+    def _create_simple_blocks(
+        self,
+        boundary_geojson: dict,
+        area_ha: float
+    ) -> gpd.GeoDataFrame:
+        """블록이 없을 때 경계를 단순 분할"""
+        geom = shape(boundary_geojson)
+        coords = list(geom.exterior.coords)
+        transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+        poly = Polygon(transformed)
+
+        # Simple 4-quadrant division
+        minx, miny, maxx, maxy = poly.bounds
+        cx = (minx + maxx) / 2
+        cy = (miny + maxy) / 2
+
+        blocks = []
+        quadrants = [
+            Polygon([(minx, cy), (cx, cy), (cx, maxy), (minx, maxy)]),  # NW
+            Polygon([(cx, cy), (maxx, cy), (maxx, maxy), (cx, maxy)]),  # NE
+            Polygon([(minx, miny), (cx, miny), (cx, cy), (minx, cy)]),  # SW
+            Polygon([(cx, miny), (maxx, miny), (maxx, cy), (cx, cy)]),  # SE
+        ]
+
+        for i, q in enumerate(quadrants):
+            intersection = poly.intersection(q)
+            if not intersection.is_empty and intersection.area > 0:
+                blocks.append({
+                    'geometry': intersection,
+                    'block_id': f'B-{i+1:03d}',
+                    'area_m2': intersection.area,
+                    'adjacent_road_width_m': 0.0,
+                    'adjacent_road_count': 0,
+                    'is_corner': False,
+                    'centroid_x': intersection.centroid.x,
+                    'centroid_y': intersection.centroid.y,
+                })
+
+        return gpd.GeoDataFrame(blocks, crs=f"EPSG:{EPSG_5179}")
+
+    def _generate_rationale(
+        self,
+        zoning_stats: dict,
+        context_analysis: dict,
+        design_params: dict,
+        similar_cases: list
+    ) -> str:
+        """설계 근거 텍스트 자동 생성"""
+        program = design_params.get('program', '혼합용도')
+        is_tod = context_analysis.get('is_tod_zone', False)
+        subway_name = context_analysis.get('nearest_subway_name', '없음')
+        subway_dist = context_analysis.get('nearest_subway_m', 9999)
+
+        lines = []
+        lines.append(f"## 토지이용계획 배치 근거\n")
+        lines.append(f"**개발 프로그램**: {program}")
+
+        if is_tod:
+            lines.append(f"**역세권 개발**: {subway_name} 역 {subway_dist:.0f}m 이내 - 고밀 복합개발 적용")
+
+        # Reference cases
+        if similar_cases:
+            best = similar_cases[0]
+            lines.append(f"\n**참조 사례**: {best['name']} (유사도 {best['similarity_score']:.0%})")
+            lines.append(f"- 시사점: {best.get('lessons', '')}")
+
+        # Zoning breakdown
+        lines.append("\n**용도지역 배치 원칙**:")
+        lines.append("- 접면도로 가장 넓은 블록 → 상업지역 배치")
+        lines.append("- 역세권 내 블록 → 준주거/제3종일반주거 고밀 배치")
+        lines.append("- 북측 블록 → 제1-2종일반주거 (일조권 보호)")
+        lines.append("- 상업-주거 완충 → 근린상업/준주거 배치")
+
+        # Stats summary
+        lines.append("\n**면적 배분 결과**:")
+        for code, stat in zoning_stats.items():
+            lines.append(f"- {stat['name']}: {stat['area_ha']:.2f}ha ({stat['ratio']*100:.1f}%)")
+
+        # Context
+        adj_n = context_analysis.get('adjacent_use_north', '미확인')
+        adj_s = context_analysis.get('adjacent_use_south', '미확인')
+        lines.append(f"\n**주변 맥락 고려**:")
+        lines.append(f"- 북측: {adj_n} | 남측: {adj_s}")
+
+        return '\n'.join(lines)

--- a/urban_planner/engine/road_generator.py
+++ b/urban_planner/engine/road_generator.py
@@ -1,0 +1,487 @@
+"""
+도로망 생성 모듈
+"""
+
+import json
+import math
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import (
+    shape, Polygon, LineString, MultiLineString, MultiPolygon, Point
+)
+from shapely.ops import unary_union, split, polygonize
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+transformer_to_wgs84 = Transformer.from_crs(EPSG_5179, EPSG_WGS84, always_xy=True)
+
+
+def _empty_gdf(columns=None) -> gpd.GeoDataFrame:
+    cols = columns or []
+    data = {c: [] for c in cols}
+    data['geometry'] = []
+    return gpd.GeoDataFrame(data, crs=f"EPSG:{EPSG_5179}")
+
+
+class RoadGenerator:
+
+    def generate(
+        self,
+        boundary_geojson: dict,
+        entry_points: list,
+        target_road_ratio: float = 0.25
+    ) -> dict:
+        """
+        반환:
+        {
+          'road_lines_gdf': GeoDataFrame,   # 도로 중심선
+          'road_polygons_gdf': GeoDataFrame, # 도로 면적(폭 적용)
+          'road_geojson': dict,
+          'road_stats': {
+            'total_length_m': float,
+            'road_area_m2': float,
+            'road_ratio': float,
+            'by_hierarchy': dict
+          }
+        }
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            boundary_geom = Polygon(transformed)
+            boundary_area = boundary_geom.area
+
+            # 1. Generate primary roads
+            primary_gdf = self._generate_primary_roads(boundary_geom, entry_points)
+
+            # 2. Generate secondary roads
+            secondary_gdf = self._generate_secondary_roads(
+                boundary_geom, primary_gdf, target_block_area_m2=10000
+            )
+
+            # 3. Combine and generate local roads
+            all_roads = self._concat_gdfs([primary_gdf, secondary_gdf])
+            local_gdf = self._generate_local_roads(
+                boundary_geom, all_roads, target_block_area_m2=5000
+            )
+
+            # 4. Combine all roads
+            road_lines_gdf = self._concat_gdfs([primary_gdf, secondary_gdf, local_gdf])
+
+            # 5. Apply road widths → polygons
+            road_polys = []
+            for idx, row in road_lines_gdf.iterrows():
+                poly = self._apply_road_width(row.geometry, row['width_m'])
+                if poly is not None and not poly.is_empty:
+                    road_polys.append({
+                        'geometry': poly.intersection(boundary_geom),
+                        'width_m': row['width_m'],
+                        'hierarchy': row['hierarchy'],
+                    })
+
+            if road_polys:
+                road_polygons_gdf = gpd.GeoDataFrame(road_polys, crs=f"EPSG:{EPSG_5179}")
+                # Remove empty geometries
+                road_polygons_gdf = road_polygons_gdf[
+                    ~road_polygons_gdf.geometry.is_empty
+                ].reset_index(drop=True)
+            else:
+                road_polygons_gdf = _empty_gdf(['width_m', 'hierarchy'])
+
+            # 6. Check and adjust road ratio
+            current_ratio = self._check_road_ratio(road_polygons_gdf, boundary_area)
+            if current_ratio < 0.18 or current_ratio > 0.32:
+                road_lines_gdf, road_polygons_gdf = self._adjust_road_ratio(
+                    road_lines_gdf, road_polygons_gdf, boundary_area, target_road_ratio
+                )
+
+            # 7. Calculate statistics
+            road_stats = self._calculate_stats(
+                road_lines_gdf, road_polygons_gdf, boundary_area
+            )
+
+            # 8. Convert to WGS84 GeoJSON
+            road_geojson = self._to_geojson(road_polygons_gdf)
+
+            return {
+                'road_lines_gdf': road_lines_gdf,
+                'road_polygons_gdf': road_polygons_gdf,
+                'road_geojson': road_geojson,
+                'road_stats': road_stats,
+            }
+
+        except Exception as e:
+            empty_lines = _empty_gdf(['width_m', 'hierarchy'])
+            empty_polys = _empty_gdf(['width_m', 'hierarchy'])
+            return {
+                'road_lines_gdf': empty_lines,
+                'road_polygons_gdf': empty_polys,
+                'road_geojson': {'type': 'FeatureCollection', 'features': []},
+                'road_stats': {
+                    'total_length_m': 0,
+                    'road_area_m2': 0,
+                    'road_ratio': 0,
+                    'by_hierarchy': {},
+                },
+            }
+
+    def _generate_primary_roads(
+        self,
+        boundary_geom: Polygon,
+        entry_points: list
+    ) -> gpd.GeoDataFrame:
+        """
+        주간선도로 생성
+        entry_points를 연결하는 주축 1~2개
+        폭원: 20~35m
+        """
+        minx, miny, maxx, maxy = boundary_geom.bounds
+        cx = (minx + maxx) / 2
+        cy = (miny + maxy) / 2
+        width = maxx - minx
+        height = maxy - miny
+
+        roads = []
+
+        if entry_points and len(entry_points) >= 2:
+            # Connect main entry points
+            # Sort by road width (widest first)
+            sorted_entries = sorted(
+                entry_points, key=lambda e: e.get('road_width_m', 0), reverse=True
+            )
+            main_entries = sorted_entries[:2]
+
+            pt1 = Point(main_entries[0]['point'][0], main_entries[0]['point'][1])
+            pt2 = Point(main_entries[1]['point'][0], main_entries[1]['point'][1])
+
+            # Primary road connecting entry points through center
+            mid_x = (pt1.x + pt2.x) / 2
+            mid_y = (pt1.y + pt2.y) / 2
+
+            # Ensure line passes through boundary center area
+            line = LineString([
+                (pt1.x, pt1.y),
+                (cx, cy),
+                (pt2.x, pt2.y)
+            ])
+            clipped = line.intersection(boundary_geom)
+            if not clipped.is_empty and clipped.length > 50:
+                if clipped.geom_type == 'LineString':
+                    roads.append({
+                        'geometry': clipped,
+                        'width_m': 25.0,
+                        'hierarchy': 'primary',
+                    })
+                elif clipped.geom_type == 'MultiLineString':
+                    for seg in clipped.geoms:
+                        if seg.length > 50:
+                            roads.append({
+                                'geometry': seg,
+                                'width_m': 25.0,
+                                'hierarchy': 'primary',
+                            })
+
+        # Add main cross axis if no entry points or only 1
+        if len(roads) == 0 or len(entry_points) <= 1:
+            # Horizontal main road through center
+            h_road = LineString([(minx, cy), (maxx, cy)])
+            clipped_h = h_road.intersection(boundary_geom)
+            if not clipped_h.is_empty and clipped_h.length > 50:
+                roads.append({
+                    'geometry': clipped_h,
+                    'width_m': 25.0,
+                    'hierarchy': 'primary',
+                })
+
+            # Vertical main road through center (if wide enough)
+            if width > height * 0.6:
+                v_road = LineString([(cx, miny), (cx, maxy)])
+                clipped_v = v_road.intersection(boundary_geom)
+                if not clipped_v.is_empty and clipped_v.length > 50:
+                    roads.append({
+                        'geometry': clipped_v,
+                        'width_m': 20.0,
+                        'hierarchy': 'primary',
+                    })
+
+        if not roads:
+            return _empty_gdf(['width_m', 'hierarchy'])
+
+        return gpd.GeoDataFrame(roads, crs=f"EPSG:{EPSG_5179}")
+
+    def _generate_secondary_roads(
+        self,
+        boundary_geom: Polygon,
+        primary_roads_gdf: gpd.GeoDataFrame,
+        target_block_area_m2: float = 10000
+    ) -> gpd.GeoDataFrame:
+        """
+        보조간선도로 생성
+        주간선 기준 블록 면적이 target_block_area_m2 될 때까지 분할
+        폭원: 12~20m
+        """
+        minx, miny, maxx, maxy = boundary_geom.bounds
+        width = maxx - minx
+        height = maxy - miny
+
+        roads = []
+
+        # Determine grid spacing based on target block area
+        # block_area ≈ spacing_x * spacing_y → use sqrt for square blocks
+        target_block_side = math.sqrt(target_block_area_m2)
+
+        # Horizontal secondary roads
+        n_h = max(1, int(height / target_block_side) - 1)
+        for i in range(1, n_h + 1):
+            y = miny + (height * i) / (n_h + 1)
+            line = LineString([(minx, y), (maxx, y)])
+            clipped = line.intersection(boundary_geom)
+            if not clipped.is_empty and clipped.length > 30:
+                geoms = [clipped] if clipped.geom_type == 'LineString' else list(clipped.geoms)
+                for g in geoms:
+                    if g.length > 30:
+                        roads.append({
+                            'geometry': g,
+                            'width_m': 15.0,
+                            'hierarchy': 'secondary',
+                        })
+
+        # Vertical secondary roads
+        n_v = max(1, int(width / target_block_side) - 1)
+        for i in range(1, n_v + 1):
+            x = minx + (width * i) / (n_v + 1)
+            line = LineString([(x, miny), (x, maxy)])
+            clipped = line.intersection(boundary_geom)
+            if not clipped.is_empty and clipped.length > 30:
+                geoms = [clipped] if clipped.geom_type == 'LineString' else list(clipped.geoms)
+                for g in geoms:
+                    if g.length > 30:
+                        roads.append({
+                            'geometry': g,
+                            'width_m': 15.0,
+                            'hierarchy': 'secondary',
+                        })
+
+        if not roads:
+            return _empty_gdf(['width_m', 'hierarchy'])
+
+        return gpd.GeoDataFrame(roads, crs=f"EPSG:{EPSG_5179}")
+
+    def _generate_local_roads(
+        self,
+        boundary_geom: Polygon,
+        all_roads_gdf: gpd.GeoDataFrame,
+        target_block_area_m2: float = 5000
+    ) -> gpd.GeoDataFrame:
+        """
+        국지도로 생성
+        블록 면적이 target_block_area_m2 초과하는 경우 추가 분할
+        막힌도로 35m 이하 제한
+        폭원: 6~12m
+        """
+        minx, miny, maxx, maxy = boundary_geom.bounds
+        width = maxx - minx
+        height = maxy - miny
+
+        # Use finer grid for local roads
+        target_block_side = math.sqrt(target_block_area_m2)
+
+        # Existing road lines as union for block detection
+        existing_lines = []
+        if not all_roads_gdf.empty:
+            for geom in all_roads_gdf.geometry:
+                existing_lines.append(geom)
+
+        roads = []
+
+        # Horizontal local roads (between secondary roads)
+        n_h = max(2, int(height / target_block_side))
+        for i in range(1, n_h):
+            y = miny + (height * i) / n_h
+            line = LineString([(minx, y), (maxx, y)])
+            clipped = line.intersection(boundary_geom)
+
+            # Check if line is too close to existing road
+            too_close = False
+            for existing in existing_lines:
+                if clipped.distance(existing) < 30:
+                    too_close = True
+                    break
+
+            if not too_close and not clipped.is_empty and clipped.length > 20:
+                geoms = [clipped] if clipped.geom_type == 'LineString' else list(clipped.geoms)
+                for g in geoms:
+                    # Enforce dead-end limit (35m max)
+                    if g.length <= 35 or g.length > 100:  # skip very short, keep reasonable
+                        if g.length > 20:
+                            roads.append({
+                                'geometry': g,
+                                'width_m': 8.0,
+                                'hierarchy': 'local',
+                            })
+
+        # Vertical local roads
+        n_v = max(2, int(width / target_block_side))
+        for i in range(1, n_v):
+            x = minx + (width * i) / n_v
+            line = LineString([(x, miny), (x, maxy)])
+            clipped = line.intersection(boundary_geom)
+
+            too_close = False
+            for existing in existing_lines:
+                if clipped.distance(existing) < 30:
+                    too_close = True
+                    break
+
+            if not too_close and not clipped.is_empty and clipped.length > 20:
+                geoms = [clipped] if clipped.geom_type == 'LineString' else list(clipped.geoms)
+                for g in geoms:
+                    if g.length > 20:
+                        roads.append({
+                            'geometry': g,
+                            'width_m': 8.0,
+                            'hierarchy': 'local',
+                        })
+
+        if not roads:
+            return _empty_gdf(['width_m', 'hierarchy'])
+
+        return gpd.GeoDataFrame(roads, crs=f"EPSG:{EPSG_5179}")
+
+    def _apply_road_width(
+        self,
+        road_line,
+        width_m: float
+    ):
+        """
+        도로 중심선에 폭원 적용 → Polygon 반환
+        shapely buffer(width_m/2) 사용
+        """
+        try:
+            if road_line is None or road_line.is_empty:
+                return None
+            buffered = road_line.buffer(width_m / 2, cap_style=2, join_style=2)
+            return buffered
+        except Exception:
+            return None
+
+    def _check_road_ratio(
+        self,
+        road_polygons_gdf: gpd.GeoDataFrame,
+        boundary_area_m2: float
+    ) -> float:
+        """
+        현재 도로율 계산 후 반환
+        """
+        if road_polygons_gdf.empty or boundary_area_m2 <= 0:
+            return 0.0
+        try:
+            road_union = unary_union(road_polygons_gdf.geometry.values)
+            road_area = road_union.area
+            return road_area / boundary_area_m2
+        except Exception:
+            return 0.0
+
+    def _adjust_road_ratio(
+        self,
+        road_lines_gdf: gpd.GeoDataFrame,
+        road_polygons_gdf: gpd.GeoDataFrame,
+        boundary_area_m2: float,
+        target_ratio: float = 0.25
+    ) -> tuple:
+        """
+        도로율 조정
+        초과(>30%): 국지도로부터 순서대로 제거
+        미달(<20%): 가장 큰 블록 추가 분할
+        반환: (조정된 road_lines_gdf, road_polygons_gdf)
+        """
+        try:
+            current = self._check_road_ratio(road_polygons_gdf, boundary_area_m2)
+
+            if current > 0.30:
+                # Remove local roads one by one until ratio drops
+                local_mask = road_lines_gdf['hierarchy'] == 'local'
+                local_indices = road_lines_gdf[local_mask].index.tolist()
+
+                for idx in local_indices:
+                    if current <= 0.28:
+                        break
+                    road_lines_gdf = road_lines_gdf.drop(idx)
+                    # Rebuild polygons
+                    road_polys = []
+                    for ridx, row in road_lines_gdf.iterrows():
+                        poly = self._apply_road_width(row.geometry, row['width_m'])
+                        if poly is not None and not poly.is_empty:
+                            road_polys.append({
+                                'geometry': poly,
+                                'width_m': row['width_m'],
+                                'hierarchy': row['hierarchy'],
+                            })
+                    if road_polys:
+                        road_polygons_gdf = gpd.GeoDataFrame(road_polys, crs=f"EPSG:{EPSG_5179}")
+                    current = self._check_road_ratio(road_polygons_gdf, boundary_area_m2)
+
+            return road_lines_gdf, road_polygons_gdf
+        except Exception:
+            return road_lines_gdf, road_polygons_gdf
+
+    def _calculate_stats(
+        self,
+        road_lines_gdf: gpd.GeoDataFrame,
+        road_polygons_gdf: gpd.GeoDataFrame,
+        boundary_area_m2: float
+    ) -> dict:
+        """도로 통계 계산"""
+        total_length = 0.0
+        by_hierarchy = {}
+
+        if not road_lines_gdf.empty:
+            total_length = float(road_lines_gdf.geometry.length.sum())
+            for hier in road_lines_gdf['hierarchy'].unique():
+                mask = road_lines_gdf['hierarchy'] == hier
+                by_hierarchy[hier] = {
+                    'count': int(mask.sum()),
+                    'total_length_m': round(float(road_lines_gdf[mask].geometry.length.sum()), 1),
+                }
+
+        road_area = 0.0
+        if not road_polygons_gdf.empty:
+            try:
+                road_union = unary_union(road_polygons_gdf.geometry.values)
+                road_area = float(road_union.area)
+            except Exception:
+                road_area = float(road_polygons_gdf.geometry.area.sum())
+
+        road_ratio = road_area / boundary_area_m2 if boundary_area_m2 > 0 else 0.0
+
+        return {
+            'total_length_m': round(total_length, 1),
+            'road_area_m2': round(road_area, 1),
+            'road_ratio': round(road_ratio, 4),
+            'by_hierarchy': by_hierarchy,
+        }
+
+    def _to_geojson(self, road_polygons_gdf: gpd.GeoDataFrame) -> dict:
+        """WGS84 GeoJSON 변환"""
+        try:
+            if road_polygons_gdf.empty:
+                return {'type': 'FeatureCollection', 'features': []}
+            wgs84 = road_polygons_gdf.to_crs(EPSG_WGS84)
+            return json.loads(wgs84.to_json())
+        except Exception:
+            return {'type': 'FeatureCollection', 'features': []}
+
+    def _concat_gdfs(self, gdfs: list) -> gpd.GeoDataFrame:
+        """여러 GeoDataFrame 합치기"""
+        non_empty = [g for g in gdfs if not g.empty]
+        if not non_empty:
+            return _empty_gdf(['width_m', 'hierarchy'])
+        import pandas as pd
+        return gpd.GeoDataFrame(
+            pd.concat(non_empty, ignore_index=True),
+            crs=f"EPSG:{EPSG_5179}"
+        )

--- a/urban_planner/engine/site_analyzer.py
+++ b/urban_planner/engine/site_analyzer.py
@@ -1,0 +1,221 @@
+"""
+대상지 현황 분석 모듈
+"""
+
+import json
+import math
+import os
+import geopandas as gpd
+from shapely.geometry import shape, Polygon
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CASE_STUDIES_PATH = os.path.join(BASE_DIR, 'reference', 'case_studies.json')
+
+
+class SiteAnalyzer:
+
+    def __init__(self):
+        self._case_studies = self._load_case_studies()
+
+    def _load_case_studies(self) -> list:
+        try:
+            with open(CASE_STUDIES_PATH, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            return data.get('cases', [])
+        except Exception:
+            return []
+
+    def analyze(
+        self,
+        boundary_geojson: dict,
+        context: dict
+    ) -> dict:
+        """
+        반환:
+        {
+          'area_m2': float,
+          'area_ha': float,
+          'perimeter_m': float,
+          'shape_index': float,
+          'terrain_type': str,
+          'similar_cases': list[dict],
+          'recommended_block_size': str,
+          'constraints': list[str],
+          'entry_point_count': int
+        }
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            poly_5179 = Polygon(transformed)
+
+            area_m2 = poly_5179.area
+            area_ha = area_m2 / 10000.0
+            perimeter_m = poly_5179.length
+
+            # Shape index: compactness ratio (1.0 = perfect circle)
+            # Shape index = perimeter / (2 * sqrt(pi * area))
+            shape_index = perimeter_m / (2 * math.sqrt(math.pi * area_m2)) if area_m2 > 0 else 1.0
+
+            # Terrain type based on context
+            terrain_type = self._estimate_terrain_type(context)
+
+            # Entry point count from context
+            entry_points = context.get('entry_points', [])
+            entry_point_count = len(entry_points)
+
+            # Get design params if provided
+            dev_type = context.get('development_type', '신규개발')
+            program = context.get('program', '혼합용도')
+
+            similar_cases = self._match_similar_cases(area_ha, dev_type, program)
+
+            # Recommended block size
+            recommended_block_size = self._recommend_block_size(area_ha, program)
+
+            # Constraints
+            constraints = self._identify_constraints(
+                area_ha, entry_point_count, context
+            )
+
+            return {
+                'area_m2': round(area_m2, 1),
+                'area_ha': round(area_ha, 2),
+                'perimeter_m': round(perimeter_m, 1),
+                'shape_index': round(shape_index, 3),
+                'terrain_type': terrain_type,
+                'similar_cases': similar_cases,
+                'recommended_block_size': recommended_block_size,
+                'constraints': constraints,
+                'entry_point_count': entry_point_count,
+            }
+        except Exception as e:
+            return {
+                'area_m2': 0.0,
+                'area_ha': 0.0,
+                'perimeter_m': 0.0,
+                'shape_index': 1.0,
+                'terrain_type': '평지',
+                'similar_cases': [],
+                'recommended_block_size': '5,000~10,000㎡',
+                'constraints': [],
+                'entry_point_count': 0,
+            }
+
+    def _estimate_terrain_type(self, context: dict) -> str:
+        """지형 유형 추정"""
+        ctx_analysis = context.get('context', {})
+        recommendations = ctx_analysis.get('recommendations', [])
+        for rec in recommendations:
+            if '구릉' in rec or '경사' in rec:
+                return '구릉지'
+            if '수변' in rec or '하천' in rec:
+                return '수변'
+        return '평지'
+
+    def _match_similar_cases(
+        self,
+        area_ha: float,
+        dev_type: str,
+        program: str
+    ) -> list:
+        """
+        reference/case_studies.json에서
+        면적/유형/프로그램 유사도로 상위 3개 반환
+        각 케이스에 similarity_score(0~1) 포함
+        """
+        if not self._case_studies:
+            return []
+
+        scored = []
+        for case in self._case_studies:
+            score = 0.0
+
+            # Area similarity (log scale)
+            case_area = case.get('area_ha', 1)
+            if case_area > 0 and area_ha > 0:
+                ratio = min(area_ha, case_area) / max(area_ha, case_area)
+                score += ratio * 0.4  # 40% weight
+
+            # Development type match
+            if case.get('type', '') == dev_type:
+                score += 0.3  # 30% weight
+
+            # Program match
+            case_prog = case.get('program', '')
+            prog_map = {
+                '주거중심': ['주거중심', '주거'],
+                '혼합용도': ['혼합용도', '복합', '자족도시'],
+                '상업중심': ['상업중심', '상업'],
+                '자족도시': ['자족도시', '혼합용도'],
+            }
+            target_progs = prog_map.get(program, [program])
+            if case_prog in target_progs or program in case_prog:
+                score += 0.3  # 30% weight
+            elif any(p in case_prog for p in target_progs):
+                score += 0.15
+
+            scored.append({**case, 'similarity_score': round(score, 3)})
+
+        scored.sort(key=lambda x: x['similarity_score'], reverse=True)
+        return scored[:3]
+
+    def _recommend_block_size(self, area_ha: float, program: str) -> str:
+        """블록 크기 권장"""
+        if program == '상업중심':
+            if area_ha < 10:
+                return '3,000~6,000㎡'
+            elif area_ha < 50:
+                return '5,000~10,000㎡'
+            else:
+                return '8,000~15,000㎡'
+        elif program == '주거중심':
+            if area_ha < 10:
+                return '3,000~5,000㎡'
+            elif area_ha < 50:
+                return '5,000~8,000㎡'
+            else:
+                return '6,000~10,000㎡'
+        else:  # 혼합용도, 자족도시
+            if area_ha < 10:
+                return '3,000~6,000㎡'
+            elif area_ha < 50:
+                return '5,000~10,000㎡'
+            else:
+                return '6,000~12,000㎡'
+
+    def _identify_constraints(
+        self,
+        area_ha: float,
+        entry_point_count: int,
+        context: dict
+    ) -> list:
+        """계획 제약 조건 식별"""
+        constraints = []
+
+        if entry_point_count == 0:
+            constraints.append("진입도로 없음: 신규 진입로 계획 필요")
+        elif entry_point_count == 1:
+            constraints.append("단일 진입점: 비상 접근성 확보 필요")
+
+        if area_ha < 1:
+            constraints.append("소규모 부지(1ha 미만): 공공시설 설치 면제 가능")
+        elif area_ha < 3:
+            constraints.append("소규모 부지(3ha 미만): 학교용지 기부채납 면제")
+
+        ctx_analysis = context.get('context', {})
+        if ctx_analysis.get('is_tod_zone'):
+            constraints.append("역세권: 주차장 설치 완화 가능, 용적률 상향 검토")
+
+        nearby_subway = ctx_analysis.get('nearest_subway_m', 9999)
+        if nearby_subway > 1000:
+            constraints.append("대중교통 취약지역: 버스 노선 확충 또는 공유 모빌리티 계획 필요")
+
+        return constraints

--- a/urban_planner/engine/validator.py
+++ b/urban_planner/engine/validator.py
@@ -1,0 +1,266 @@
+"""
+도시계획 법규 검증 모듈
+국토계획법 및 서울시 도시계획 조례 기준
+"""
+
+import geopandas as gpd
+from shapely.geometry import shape, Polygon
+from pyproj import Transformer
+
+EPSG_WGS84 = 4326
+EPSG_5179 = 5179
+
+transformer_to_5179 = Transformer.from_crs(EPSG_WGS84, EPSG_5179, always_xy=True)
+
+
+class PlanValidator:
+
+    def validate(
+        self,
+        boundary_geojson: dict,
+        road_stats: dict,
+        blocks_gdf: gpd.GeoDataFrame,
+        facilities_gdf: gpd.GeoDataFrame,
+        zoning_stats: dict
+    ) -> dict:
+        """
+        반환:
+        {
+          'is_valid': bool,
+          'score': int,           # 0~100점
+          'required': [
+            {'item': str, 'pass': bool, 'value': str, 'standard': str}
+          ],
+          'recommended': [
+            {'item': str, 'pass': bool, 'value': str, 'standard': str}
+          ],
+          'issues': list[dict]
+        }
+        """
+        try:
+            geom = shape(boundary_geojson)
+            coords = list(geom.exterior.coords)
+            transformed = [transformer_to_5179.transform(lon, lat) for lon, lat in coords]
+            boundary_geom = Polygon(transformed)
+            total_area_m2 = boundary_geom.area
+            total_area_ha = total_area_m2 / 10000
+
+            required_checks = []
+            recommended_checks = []
+            issues = []
+
+            # ==================
+            # REQUIRED CHECKS
+            # ==================
+
+            # 1. 도로율 (20~30%)
+            road_ratio = road_stats.get('road_ratio', 0)
+            road_pct = road_ratio * 100
+            road_pass = 0.20 <= road_ratio <= 0.30
+            required_checks.append({
+                'item': '도로율',
+                'pass': road_pass,
+                'value': f'{road_pct:.1f}%',
+                'standard': '20~30%',
+            })
+            if not road_pass:
+                issues.append({
+                    'severity': 'error',
+                    'item': '도로율',
+                    'message': f'도로율 {road_pct:.1f}%는 기준 범위(20~30%)를 벗어남',
+                })
+
+            # 2. 녹지율 (최소 10%)
+            green_area = sum(
+                s.get('area_m2', 0)
+                for code, s in zoning_stats.items()
+                if code in ('GN', 'PK')
+            )
+            facility_park_area = 0.0
+            if not facilities_gdf.empty and 'facility_type' in facilities_gdf.columns:
+                park_types = ['neighborhood_park', 'children_park']
+                park_gdf = facilities_gdf[facilities_gdf['facility_type'].isin(park_types)]
+                facility_park_area = float(park_gdf.geometry.area.sum())
+
+            total_green = green_area + facility_park_area
+            green_ratio = total_green / total_area_m2 if total_area_m2 > 0 else 0
+            green_pct = green_ratio * 100
+            green_pass = green_ratio >= 0.10
+            required_checks.append({
+                'item': '녹지율',
+                'pass': green_pass,
+                'value': f'{green_pct:.1f}%',
+                'standard': '최소 10%',
+            })
+            if not green_pass:
+                issues.append({
+                    'severity': 'error',
+                    'item': '녹지율',
+                    'message': f'녹지율 {green_pct:.1f}%가 최소 기준(10%) 미달',
+                })
+
+            # 3. 블록 수 (최소 2개 이상)
+            block_count = len(blocks_gdf) if not blocks_gdf.empty else 0
+            block_pass = block_count >= 2
+            required_checks.append({
+                'item': '블록 분할',
+                'pass': block_pass,
+                'value': f'{block_count}개',
+                'standard': '최소 2개',
+            })
+
+            # 4. 최소 진입도로 (접면도로 폭 6m 이상)
+            if not blocks_gdf.empty and 'adjacent_road_width_m' in blocks_gdf.columns:
+                min_road_width = float(blocks_gdf['adjacent_road_width_m'].min())
+                access_pass = min_road_width >= 6.0 or block_count <= 1
+            else:
+                min_road_width = 0.0
+                access_pass = False
+            required_checks.append({
+                'item': '최소 접면도로',
+                'pass': access_pass,
+                'value': f'{min_road_width:.1f}m',
+                'standard': '6m 이상',
+            })
+            if not access_pass:
+                issues.append({
+                    'severity': 'error',
+                    'item': '접면도로',
+                    'message': f'일부 블록 접면도로 폭({min_road_width:.1f}m)이 6m 미달',
+                })
+
+            # 5. 공원 면적 (주거인구 1인당 3㎡ 이상)
+            total_green_for_park = total_green
+            # Estimate residential population
+            res_area = sum(
+                s.get('area_m2', 0)
+                for code, s in zoning_stats.items()
+                if code in ('R1', 'R2', 'R3', 'R4', 'R5', 'RQ')
+            )
+            # Estimate population from residential area
+            est_pop = max(100, int(res_area * 0.015))  # ~150 persons/ha → 0.015/m²
+            park_per_person = total_green_for_park / est_pop if est_pop > 0 else 0
+            park_std_pass = park_per_person >= 3.0
+            required_checks.append({
+                'item': '1인당 공원면적',
+                'pass': park_std_pass,
+                'value': f'{park_per_person:.1f}㎡/인',
+                'standard': '3㎡/인 이상',
+            })
+            if not park_std_pass:
+                issues.append({
+                    'severity': 'warning',
+                    'item': '공원면적',
+                    'message': f'1인당 공원면적 {park_per_person:.1f}㎡가 권장 기준(3㎡) 미달',
+                })
+
+            # ==================
+            # RECOMMENDED CHECKS
+            # ==================
+
+            # 6. 주간선도로 폭원 (20m 이상)
+            by_hierarchy = road_stats.get('by_hierarchy', {})
+            has_primary = 'primary' in by_hierarchy
+            primary_pass = has_primary
+            recommended_checks.append({
+                'item': '주간선도로',
+                'pass': primary_pass,
+                'value': '있음' if has_primary else '없음',
+                'standard': '폭원 20m 이상 1개 이상',
+            })
+
+            # 7. 공원 서비스 반경 (250m 커버리지 70% 이상)
+            park_coverage_250 = 0.0
+            if not facilities_gdf.empty:
+                # Already calculated in facility placer - use rough estimate here
+                park_types = ['neighborhood_park', 'children_park']
+                if 'facility_type' in facilities_gdf.columns:
+                    parks = facilities_gdf[facilities_gdf['facility_type'].isin(park_types)]
+                    if not parks.empty and not blocks_gdf.empty:
+                        total_block_area = float(blocks_gdf.geometry.area.sum())
+                        park_zones = parks.geometry.buffer(250)
+                        from shapely.ops import unary_union
+                        union_zone = unary_union(park_zones)
+                        covered = float(
+                            blocks_gdf.geometry.intersection(union_zone).area.sum()
+                        )
+                        park_coverage_250 = covered / total_block_area if total_block_area > 0 else 0
+            park_cov_pass = park_coverage_250 >= 0.70
+            recommended_checks.append({
+                'item': '공원 서비스 반경(250m)',
+                'pass': park_cov_pass,
+                'value': f'{park_coverage_250*100:.1f}%',
+                'standard': '70% 이상',
+            })
+            if not park_cov_pass:
+                issues.append({
+                    'severity': 'info',
+                    'item': '공원 접근성',
+                    'message': f'공원 250m 커버리지 {park_coverage_250*100:.1f}%가 권장 기준(70%) 미달',
+                })
+
+            # 8. 블록 평균 크기 (3,000~15,000㎡)
+            avg_block_area = 0.0
+            if not blocks_gdf.empty and 'area_m2' in blocks_gdf.columns:
+                avg_block_area = float(blocks_gdf['area_m2'].mean())
+            block_size_pass = 3000 <= avg_block_area <= 15000
+            recommended_checks.append({
+                'item': '평균 블록 크기',
+                'pass': block_size_pass,
+                'value': f'{avg_block_area:.0f}㎡',
+                'standard': '3,000~15,000㎡',
+            })
+
+            # 9. 상업지역 비율 (30% 이하)
+            commercial_area = sum(
+                s.get('area_m2', 0)
+                for code, s in zoning_stats.items()
+                if code in ('CB', 'CG', 'CN')
+            )
+            commercial_ratio = commercial_area / total_area_m2 if total_area_m2 > 0 else 0
+            commercial_pass = commercial_ratio <= 0.30
+            recommended_checks.append({
+                'item': '상업지역 비율',
+                'pass': commercial_pass,
+                'value': f'{commercial_ratio*100:.1f}%',
+                'standard': '30% 이하',
+            })
+
+            # 10. 도로망 연결성 (보조간선도로 존재)
+            has_secondary = 'secondary' in by_hierarchy
+            conn_pass = has_secondary
+            recommended_checks.append({
+                'item': '도로망 위계',
+                'pass': conn_pass,
+                'value': '있음' if has_secondary else '없음',
+                'standard': '보조간선도로 포함',
+            })
+
+            # ==================
+            # SCORE CALCULATION
+            # ==================
+            required_passed = sum(1 for c in required_checks if c['pass'])
+            recommended_passed = sum(1 for c in recommended_checks if c['pass'])
+
+            required_score = (required_passed / len(required_checks)) * 60 if required_checks else 0
+            recommended_score = (recommended_passed / len(recommended_checks)) * 40 if recommended_checks else 0
+            total_score = int(required_score + recommended_score)
+
+            is_valid = required_passed >= len(required_checks) - 1  # 필수 1개 이하 실패
+
+            return {
+                'is_valid': is_valid,
+                'score': total_score,
+                'required': required_checks,
+                'recommended': recommended_checks,
+                'issues': issues,
+            }
+
+        except Exception as e:
+            return {
+                'is_valid': False,
+                'score': 0,
+                'required': [],
+                'recommended': [],
+                'issues': [{'severity': 'error', 'item': '검증 오류', 'message': str(e)}],
+            }

--- a/urban_planner/main.py
+++ b/urban_planner/main.py
@@ -1,0 +1,209 @@
+"""
+한국 도시설계 토지이용계획 수립 툴
+FastAPI 메인 애플리케이션
+실행: uvicorn main:app --reload --port 8000
+"""
+
+import os
+import traceback
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+# Change working directory to the app directory
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+from engine import (
+    ContextFetcher,
+    SiteAnalyzer,
+    MasterPlanner,
+    RoadGenerator,
+    BlockDivider,
+    FacilityPlacer,
+    PlanValidator,
+)
+
+app = FastAPI(
+    title="한국 도시설계 토지이용계획 수립 툴",
+    description="Korean Urban Planning Land Use Planning Tool",
+    version="1.0.0",
+)
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+class PlanRequest(BaseModel):
+    boundary_geojson: dict
+    site_name: str = "테스트 구역"
+    development_type: str = "신규개발"
+    program: str = "혼합용도"
+    target_population: int = 0
+    target_far: float = 0
+    green_ratio_min: float = 0.10
+    road_ratio_target: float = 0.25
+    region: str = "서울"
+    transit_access: str = "없음"
+    priority: dict = {
+        "density": 3,
+        "green": 3,
+        "walkability": 3,
+        "publicfacility": 3,
+        "traffic": 3,
+    }
+
+
+@app.get("/")
+async def root():
+    return FileResponse("static/index.html")
+
+
+@app.post("/api/analyze")
+async def analyze(request: PlanRequest):
+    try:
+        fetcher = ContextFetcher()
+        context = fetcher.fetch_context(request.boundary_geojson)
+        analyzer = SiteAnalyzer()
+        result = analyzer.analyze(request.boundary_geojson, context)
+        return {"success": True, "data": result}
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+        }
+
+
+@app.post("/api/plan")
+async def create_plan(request: PlanRequest):
+    try:
+        # 1. 컨텍스트 수집
+        fetcher = ContextFetcher()
+        context_raw = fetcher.fetch_context(
+            request.boundary_geojson, buffer_m=500
+        )
+        entry_points = fetcher.get_entry_points(
+            request.boundary_geojson,
+            context_raw['roads_gdf']
+        )
+        context_analysis = fetcher.analyze_surroundings(
+            request.boundary_geojson,
+            context_raw['roads_gdf'],
+            context_raw['landuse_gdf'],
+            context_raw['facilities_gdf'],
+            context_raw['subway_stations']
+        )
+
+        # 2. 현황 분석
+        analyzer = SiteAnalyzer()
+        site_analysis = analyzer.analyze(
+            request.boundary_geojson,
+            {
+                'context': context_analysis,
+                'entry_points': entry_points,
+                'development_type': request.development_type,
+                'program': request.program,
+            }
+        )
+
+        # 3. 도로망 생성
+        road_gen = RoadGenerator()
+        road_result = road_gen.generate(
+            request.boundary_geojson,
+            entry_points,
+            target_road_ratio=request.road_ratio_target
+        )
+
+        # 4. 블록 분할
+        divider = BlockDivider()
+        block_result = divider.divide(
+            request.boundary_geojson,
+            road_result['road_polygons_gdf']
+        )
+
+        # 5. 토지이용계획
+        planner = MasterPlanner()
+        design_params = request.dict()
+        # Pass blocks to planner for zoning assignment
+        design_params['_blocks_gdf'] = block_result['blocks_gdf']
+        plan_result = planner.plan(
+            request.boundary_geojson,
+            site_analysis,
+            design_params,
+            context_analysis
+        )
+
+        # 6. 공공시설 배치
+        placer = FacilityPlacer()
+        facility_result = placer.place(
+            block_result['blocks_gdf'],
+            design_params,
+            context_raw
+        )
+
+        # 7. 법규 검증
+        validator = PlanValidator()
+        validation = validator.validate(
+            request.boundary_geojson,
+            road_result['road_stats'],
+            block_result['blocks_gdf'],
+            facility_result['facilities_gdf'],
+            plan_result['zoning_stats']
+        )
+
+        # Build context GeoJSON (safely)
+        context_geojson = {}
+        try:
+            if not context_raw['roads_gdf'].empty:
+                context_geojson['roads'] = context_raw['roads_gdf'].to_crs(4326).to_json()
+            else:
+                context_geojson['roads'] = None
+        except Exception:
+            context_geojson['roads'] = None
+
+        try:
+            if not context_raw['landuse_gdf'].empty:
+                context_geojson['landuse'] = context_raw['landuse_gdf'].to_crs(4326).to_json()
+            else:
+                context_geojson['landuse'] = None
+        except Exception:
+            context_geojson['landuse'] = None
+
+        return {
+            "success": True,
+            "data": {
+                "site_analysis": site_analysis,
+                "context_analysis": context_analysis,
+                "entry_points": entry_points,
+                "context_geojson": context_geojson,
+                "roads": road_result['road_geojson'],
+                "blocks": block_result['blocks_geojson'],
+                "zoning": plan_result['zoning_geojson'],
+                "facilities": facility_result['facilities_geojson'],
+                "validation": validation,
+                "road_stats": road_result['road_stats'],
+                "block_stats": block_result['block_stats'],
+                "zoning_stats": plan_result['zoning_stats'],
+                "coverage": facility_result['coverage'],
+                "design_rationale": plan_result['design_rationale'],
+                "subway_stations": context_raw['subway_stations'],
+                "bus_stops": context_raw['bus_stops'],
+            },
+        }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+        }
+
+
+@app.get("/api/health")
+async def health():
+    return {"status": "ok", "message": "Urban Planning Tool is running"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)

--- a/urban_planner/reference/case_studies.json
+++ b/urban_planner/reference/case_studies.json
@@ -1,0 +1,88 @@
+{
+  "cases": [
+    {
+      "id": "hanam_misa",
+      "name": "하남 미사강변도시",
+      "type": "신규개발", "program": "주거중심",
+      "area_ha": 546, "population": 93000,
+      "characteristics": ["수변","친환경"],
+      "zoning_mix": {"residential":0.45,"commercial":0.08,
+        "industrial":0.0,"green":0.25,"public":0.12,"road":0.10},
+      "road_density": 8.5,
+      "avg_block_size_m2": 8000, "far_avg": 180,
+      "lessons": "수변 완충녹지, 자전거도로 연계"
+    },
+    {
+      "id": "sejong_1",
+      "name": "세종시 1생활권",
+      "type": "신규개발", "program": "혼합용도",
+      "area_ha": 420, "population": 65000,
+      "characteristics": ["행정","보행중심","BRT"],
+      "zoning_mix": {"residential":0.40,"commercial":0.10,
+        "industrial":0.0,"green":0.28,"public":0.12,"road":0.10},
+      "road_density": 9.2,
+      "avg_block_size_m2": 6500, "far_avg": 200,
+      "lessons": "BRT 중심 TOD, 공공시설 집약"
+    },
+    {
+      "id": "incheon_songdo",
+      "name": "인천 송도국제도시",
+      "type": "신규개발", "program": "상업중심",
+      "area_ha": 611, "population": 90000,
+      "characteristics": ["국제업무","스마트","수변"],
+      "zoning_mix": {"residential":0.30,"commercial":0.20,
+        "industrial":0.05,"green":0.25,"public":0.10,"road":0.10},
+      "road_density": 7.8,
+      "avg_block_size_m2": 12000, "far_avg": 280,
+      "lessons": "격자형 도로망, 중앙공원 축"
+    },
+    {
+      "id": "seoul_eunpyeong",
+      "name": "서울 은평뉴타운",
+      "type": "재개발", "program": "주거중심",
+      "area_ha": 349, "population": 56000,
+      "characteristics": ["구릉지","재개발"],
+      "zoning_mix": {"residential":0.55,"commercial":0.06,
+        "industrial":0.0,"green":0.20,"public":0.09,"road":0.10},
+      "road_density": 7.2,
+      "avg_block_size_m2": 5500, "far_avg": 220,
+      "lessons": "지형 순응 도로망, 경사지 공원화"
+    },
+    {
+      "id": "gwanggyo",
+      "name": "광교신도시",
+      "type": "신규개발", "program": "자족도시",
+      "area_ha": 1129, "population": 78000,
+      "characteristics": ["자족","친환경","수변"],
+      "zoning_mix": {"residential":0.42,"commercial":0.09,
+        "industrial":0.05,"green":0.30,"public":0.07,"road":0.07},
+      "road_density": 6.5,
+      "avg_block_size_m2": 9000, "far_avg": 175,
+      "lessons": "호수공원 중심축, 대규모 녹지"
+    },
+    {
+      "id": "gimpo_hangang",
+      "name": "김포 한강신도시",
+      "type": "신규개발", "program": "주거중심",
+      "area_ha": 1170, "population": 176000,
+      "characteristics": ["수변","대규모"],
+      "zoning_mix": {"residential":0.50,"commercial":0.07,
+        "industrial":0.0,"green":0.22,"public":0.11,"road":0.10},
+      "road_density": 8.0,
+      "avg_block_size_m2": 7000, "far_avg": 190,
+      "lessons": "광역교통 연계, 단지별 특화"
+    },
+    {
+      "id": "pangyo",
+      "name": "판교신도시",
+      "type": "신규개발", "program": "자족도시",
+      "area_ha": 930, "population": 88000,
+      "characteristics": ["자족","IT","친환경"],
+      "zoning_mix": {"residential":0.38,"commercial":0.12,
+        "industrial":0.08,"green":0.25,"public":0.08,"road":0.09},
+      "road_density": 7.5,
+      "avg_block_size_m2": 10000, "far_avg": 200,
+      "lessons": "IT클러스터, 보행가로 특화"
+    }
+  ]
+}

--- a/urban_planner/requirements.txt
+++ b/urban_planner/requirements.txt
@@ -1,0 +1,12 @@
+fastapi>=0.104.0
+uvicorn>=0.24.0
+geopandas>=0.14.0
+shapely>=2.0.0
+pyproj>=3.6.0
+networkx>=3.2.0
+requests>=2.31.0
+numpy>=1.26.0
+scipy>=1.11.0
+matplotlib>=3.8.0
+pyyaml>=6.0.1
+python-multipart>=0.0.6

--- a/urban_planner/rules/facility_rules.yaml
+++ b/urban_planner/rules/facility_rules.yaml
@@ -1,0 +1,59 @@
+# 공공시설 배치 기준 (도시공원 및 녹지 등에 관한 법률, 학교시설기준)
+parks:
+  neighborhood:
+    name: "근린공원"
+    area_min_m2: 10000
+    area_max_m2: 100000
+    service_radius_m: 500
+    households_per_park: 1000
+    min_ratio: 0.05  # 전체 면적 대비
+
+  children:
+    name: "어린이공원"
+    area_min_m2: 1500
+    area_max_m2: 5000
+    service_radius_m: 250
+    households_per_park: 300
+    min_ratio: 0.02
+
+schools:
+  elementary:
+    name: "초등학교"
+    area_min_m2: 5000
+    area_max_m2: 10000
+    service_radius_m: 500
+    households_per_school: 500
+    persons_per_household: 2.5
+
+  middle:
+    name: "중학교"
+    area_min_m2: 8000
+    area_max_m2: 15000
+    service_radius_m: 1000
+    households_per_school: 2000
+
+  high:
+    name: "고등학교"
+    area_min_m2: 10000
+    area_max_m2: 20000
+    service_radius_m: 1500
+    households_per_school: 3000
+
+public_facilities:
+  community_center:
+    name: "주민센터"
+    area_min_m2: 1000
+    area_max_m2: 3000
+    households_per_facility: 2000
+
+  welfare_center:
+    name: "복지관"
+    area_min_m2: 2000
+    area_max_m2: 5000
+    population_per_facility: 10000
+
+# 녹지율 기준
+green_ratio:
+  residential_min: 0.10
+  mixed_min: 0.08
+  commercial_min: 0.05

--- a/urban_planner/rules/road_rules.yaml
+++ b/urban_planner/rules/road_rules.yaml
@@ -1,0 +1,53 @@
+# 도로 설계 기준 (도시·군계획시설의 결정·구조 및 설치기준에 관한 규칙)
+road_hierarchy:
+  primary:
+    name: "주간선도로"
+    width_min_m: 20
+    width_max_m: 35
+    width_default_m: 25
+    block_area_target_m2: 50000
+    dead_end_max_m: null
+    speed_kph: 60
+  secondary:
+    name: "보조간선도로"
+    width_min_m: 12
+    width_max_m: 20
+    width_default_m: 15
+    block_area_target_m2: 10000
+    dead_end_max_m: null
+    speed_kph: 40
+  local:
+    name: "국지도로"
+    width_min_m: 6
+    width_max_m: 12
+    width_default_m: 8
+    block_area_target_m2: 5000
+    dead_end_max_m: 35
+    speed_kph: 20
+
+road_ratios:
+  min: 0.20
+  target: 0.25
+  max: 0.30
+
+# OSM 도로 태그 → 위계 매핑
+osm_to_hierarchy:
+  motorway: primary
+  trunk: primary
+  primary: primary
+  secondary: secondary
+  tertiary: secondary
+  residential: local
+  service: local
+  unclassified: local
+
+# 도로 폭원 추정 (OSM highway 태그 기준)
+osm_width_estimate_m:
+  motorway: 30
+  trunk: 25
+  primary: 20
+  secondary: 15
+  tertiary: 12
+  residential: 8
+  service: 6
+  unclassified: 8

--- a/urban_planner/rules/zoning_rules.yaml
+++ b/urban_planner/rules/zoning_rules.yaml
@@ -1,0 +1,80 @@
+# 서울시 기준 (국토계획법 + 서울시 도시계획 조례)
+zoning:
+  R1:
+    name: "제1종전용주거지역"
+    far_max: 100
+    bcr_max: 50
+    height_max: 9
+    floor_max: 2
+  R2:
+    name: "제2종전용주거지역"
+    far_max: 120
+    bcr_max: 40
+    height_max: null
+    floor_max: 4
+  R3:
+    name: "제1종일반주거지역"
+    far_max: 150
+    bcr_max: 60
+    height_max: null
+    floor_max: 4
+  R4:
+    name: "제2종일반주거지역"
+    far_max: 200
+    bcr_max: 60
+    height_max: null
+    floor_max: 18
+  R5:
+    name: "제3종일반주거지역"
+    far_max: 300
+    bcr_max: 50
+    height_max: null
+    floor_max: null
+  RQ:
+    name: "준주거지역"
+    far_max: 500
+    bcr_max: 70
+    height_max: null
+    floor_max: null
+  CB:
+    name: "중심상업지역"
+    far_max: 1000
+    bcr_max: 90
+    height_max: null
+    floor_max: null
+  CG:
+    name: "일반상업지역"
+    far_max: 800
+    bcr_max: 80
+    height_max: null
+    floor_max: null
+  CN:
+    name: "근린상업지역"
+    far_max: 600
+    bcr_max: 70
+    height_max: null
+    floor_max: null
+  IQ:
+    name: "준공업지역"
+    far_max: 400
+    bcr_max: 70
+    height_max: null
+    floor_max: null
+  GN:
+    name: "자연녹지지역"
+    far_max: 100
+    bcr_max: 20
+    height_max: null
+    floor_max: null
+  PK:
+    name: "공원"
+    far_max: 0
+    bcr_max: 0
+    height_max: null
+    floor_max: null
+  PF:
+    name: "공공시설"
+    far_max: 200
+    bcr_max: 60
+    height_max: null
+    floor_max: null

--- a/urban_planner/static/index.html
+++ b/urban_planner/static/index.html
@@ -1,0 +1,1174 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>한국 도시설계 토지이용계획 수립 툴</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Malgun Gothic', '맑은 고딕', sans-serif; font-size: 13px; background: #1a1a2e; color: #e0e0e0; display: flex; height: 100vh; overflow: hidden; }
+
+/* ── Left Panel ── */
+#left-panel {
+  width: 300px; min-width: 300px; background: #16213e;
+  display: flex; flex-direction: column; border-right: 1px solid #0f3460;
+  overflow: hidden;
+}
+#left-panel h2 {
+  background: linear-gradient(135deg, #0f3460, #533483);
+  color: #fff; padding: 14px 16px; font-size: 14px;
+  border-bottom: 2px solid #e94560; flex-shrink: 0;
+}
+#left-panel h2 span { font-size: 10px; color: #aaa; display: block; margin-top: 2px; }
+.form-scroll { overflow-y: auto; flex: 1; padding: 12px; }
+.form-section { background: #0f3460; border-radius: 6px; padding: 10px; margin-bottom: 10px; }
+.form-section h3 { color: #e94560; font-size: 11px; text-transform: uppercase; margin-bottom: 8px; letter-spacing: 1px; }
+.field { margin-bottom: 8px; }
+.field label { display: block; color: #aaa; font-size: 11px; margin-bottom: 3px; }
+.field input, .field select, .field textarea {
+  width: 100%; background: #1a1a2e; border: 1px solid #0f3460;
+  color: #e0e0e0; padding: 6px 8px; border-radius: 4px; font-size: 12px;
+}
+.field input:focus, .field select:focus { outline: none; border-color: #e94560; }
+.field textarea { height: 60px; resize: none; font-size: 11px; }
+.priority-row { display: flex; align-items: center; gap: 6px; margin-bottom: 5px; }
+.priority-row label { color: #aaa; font-size: 11px; width: 70px; flex-shrink: 0; }
+.priority-row input[type=range] { flex: 1; accent-color: #e94560; }
+.priority-row span { color: #e94560; font-size: 11px; width: 16px; text-align: right; }
+
+#btn-draw { width: 100%; background: #533483; color: #fff; border: none; padding: 9px; border-radius: 4px; cursor: pointer; font-size: 12px; margin-bottom: 6px; }
+#btn-draw:hover { background: #7b52b9; }
+#btn-plan { width: 100%; background: linear-gradient(135deg, #e94560, #c23152); color: #fff; border: none; padding: 10px; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: bold; }
+#btn-plan:hover { background: linear-gradient(135deg, #ff6b8a, #e94560); }
+#btn-plan:disabled { background: #444; cursor: not-allowed; }
+#btn-clear { width: 100%; background: #333; color: #aaa; border: none; padding: 7px; border-radius: 4px; cursor: pointer; font-size: 11px; margin-top: 5px; }
+#btn-clear:hover { background: #444; }
+
+.status-bar { background: #0f3460; padding: 8px 12px; font-size: 11px; color: #aaa; border-top: 1px solid #533483; flex-shrink: 0; }
+.status-bar.error { color: #e94560; }
+.status-bar.success { color: #2ecc71; }
+
+/* ── Map Panel ── */
+#map-container { flex: 1; position: relative; }
+#map { width: 100%; height: 100%; }
+
+.map-legend {
+  position: absolute; bottom: 20px; left: 10px; z-index: 1000;
+  background: rgba(22,33,62,0.92); border: 1px solid #0f3460;
+  border-radius: 6px; padding: 10px 12px; max-width: 180px;
+}
+.map-legend h4 { color: #e94560; font-size: 11px; margin-bottom: 6px; }
+.legend-item { display: flex; align-items: center; gap: 6px; margin-bottom: 3px; font-size: 10px; color: #ccc; }
+.legend-color { width: 14px; height: 14px; border-radius: 2px; flex-shrink: 0; border: 1px solid rgba(255,255,255,0.2); }
+
+.layer-controls {
+  position: absolute; top: 10px; right: 10px; z-index: 1000;
+  background: rgba(22,33,62,0.92); border: 1px solid #0f3460;
+  border-radius: 6px; padding: 8px 10px;
+}
+.layer-controls h4 { color: #e94560; font-size: 10px; margin-bottom: 5px; }
+.layer-toggle { display: flex; align-items: center; gap: 5px; margin-bottom: 3px; font-size: 10px; color: #ccc; cursor: pointer; }
+.layer-toggle input { accent-color: #e94560; }
+
+/* ── Right Panel ── */
+#right-panel {
+  width: 350px; min-width: 350px; background: #16213e;
+  display: flex; flex-direction: column; border-left: 1px solid #0f3460;
+  overflow: hidden;
+}
+#right-panel h2 { background: linear-gradient(135deg, #0f3460, #533483); color: #fff; padding: 14px 16px; font-size: 14px; border-bottom: 2px solid #e94560; flex-shrink: 0; }
+
+.tabs { display: flex; background: #0f3460; flex-shrink: 0; }
+.tab-btn { flex: 1; padding: 8px 4px; font-size: 11px; color: #aaa; background: transparent; border: none; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.2s; }
+.tab-btn.active { color: #e94560; border-bottom-color: #e94560; }
+.tab-btn:hover { color: #fff; }
+
+.tab-content { display: none; flex: 1; overflow-y: auto; padding: 12px; }
+.tab-content.active { display: block; }
+
+/* Stats */
+.stat-card { background: #0f3460; border-radius: 6px; padding: 10px; margin-bottom: 8px; }
+.stat-card h4 { color: #e94560; font-size: 11px; margin-bottom: 6px; text-transform: uppercase; }
+.stat-row { display: flex; justify-content: space-between; align-items: center; padding: 3px 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 11px; }
+.stat-row:last-child { border-bottom: none; }
+.stat-label { color: #aaa; }
+.stat-value { color: #fff; font-weight: bold; }
+
+.zoning-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.zoning-table th { background: #1a1a2e; color: #aaa; padding: 4px 6px; text-align: left; }
+.zoning-table td { padding: 4px 6px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+.zoning-color-cell { width: 14px; height: 14px; border-radius: 2px; display: inline-block; }
+
+.gauge-bar-wrap { margin: 4px 0 8px; }
+.gauge-label { display: flex; justify-content: space-between; font-size: 10px; color: #aaa; margin-bottom: 2px; }
+.gauge-track { height: 8px; background: #1a1a2e; border-radius: 4px; overflow: hidden; position: relative; }
+.gauge-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
+.gauge-fill.good { background: #2ecc71; }
+.gauge-fill.bad { background: #e94560; }
+.gauge-marks { position: relative; height: 4px; margin-top: 2px; }
+.gauge-mark { position: absolute; width: 1px; height: 4px; background: #555; }
+.gauge-mark-label { position: absolute; font-size: 9px; color: #555; transform: translateX(-50%); top: -2px; }
+
+/* Validation */
+.check-list { list-style: none; }
+.check-item { display: flex; align-items: flex-start; gap: 8px; padding: 6px 8px; border-radius: 4px; margin-bottom: 4px; background: #0f3460; font-size: 11px; }
+.check-item .icon { font-size: 13px; flex-shrink: 0; margin-top: 1px; }
+.check-item .detail { color: #aaa; font-size: 10px; margin-top: 1px; }
+.check-item.pass { border-left: 3px solid #2ecc71; }
+.check-item.fail { border-left: 3px solid #e94560; }
+.section-header { color: #e94560; font-size: 11px; font-weight: bold; text-transform: uppercase; margin: 8px 0 5px; letter-spacing: 1px; }
+.score-circle { width: 80px; height: 80px; border-radius: 50%; border: 4px solid #e94560; display: flex; align-items: center; justify-content: center; flex-direction: column; margin: 0 auto 12px; }
+.score-num { font-size: 26px; font-weight: bold; color: #e94560; line-height: 1; }
+.score-label { font-size: 9px; color: #aaa; }
+
+/* Context */
+.compass-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 4px; margin-bottom: 8px; }
+.compass-cell { background: #0f3460; border-radius: 4px; padding: 6px; text-align: center; font-size: 10px; }
+.compass-cell.center { background: #533483; }
+.compass-dir { color: #e94560; font-size: 9px; display: block; }
+.compass-use { color: #fff; font-size: 11px; }
+.info-badge { display: inline-block; background: #0f3460; border-radius: 12px; padding: 3px 8px; font-size: 11px; margin: 2px; color: #e0e0e0; }
+.info-badge.active { background: #533483; color: #fff; }
+.rec-item { background: #0f3460; border-radius: 4px; padding: 6px 8px; margin-bottom: 4px; font-size: 11px; color: #ccc; border-left: 3px solid #533483; }
+
+/* Report */
+.report-text { background: #0f3460; border-radius: 6px; padding: 12px; font-size: 11px; line-height: 1.7; color: #ccc; white-space: pre-wrap; }
+.report-section { margin-bottom: 12px; }
+.report-section h4 { color: #e94560; margin-bottom: 6px; font-size: 12px; }
+#btn-export { width: 100%; background: #533483; color: #fff; border: none; padding: 8px; border-radius: 4px; cursor: pointer; font-size: 11px; margin-bottom: 8px; }
+
+/* Loading overlay */
+#loading-overlay {
+  display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+  background: rgba(0,0,0,0.7); z-index: 9999; align-items: center; justify-content: center; flex-direction: column;
+}
+#loading-overlay.show { display: flex; }
+.spinner { width: 50px; height: 50px; border: 4px solid #333; border-top-color: #e94560; border-radius: 50%; animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.loading-msg { color: #fff; margin-top: 16px; font-size: 14px; }
+.loading-steps { color: #aaa; font-size: 12px; margin-top: 6px; }
+
+/* Block label */
+.block-label { background: transparent; border: none; color: #fff; font-size: 10px; font-weight: bold; text-shadow: 0 0 3px #000, 0 0 3px #000; white-space: nowrap; pointer-events: none; }
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: #0f3460; }
+::-webkit-scrollbar-thumb { background: #533483; border-radius: 2px; }
+</style>
+</head>
+<body>
+
+<!-- Left Panel -->
+<div id="left-panel">
+  <h2>🏙 도시설계 토지이용계획 툴
+    <span>Korean Urban Planning Tool v1.0</span>
+  </h2>
+  <div class="form-scroll">
+
+    <div class="form-section">
+      <h3>📍 대상지 설정</h3>
+      <div class="field">
+        <label>구역 이름</label>
+        <input type="text" id="site-name" value="신도시 개발구역" placeholder="구역명 입력">
+      </div>
+      <div class="field">
+        <label>개발 유형</label>
+        <select id="dev-type">
+          <option value="신규개발">신규개발</option>
+          <option value="재개발">재개발</option>
+          <option value="재건축">재건축</option>
+          <option value="도시정비">도시정비</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>개발 프로그램</label>
+        <select id="program">
+          <option value="혼합용도">혼합용도</option>
+          <option value="주거중심">주거중심</option>
+          <option value="상업중심">상업중심</option>
+          <option value="자족도시">자족도시</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>지역</label>
+        <select id="region">
+          <option value="서울">서울</option>
+          <option value="경기">경기</option>
+          <option value="인천">인천</option>
+          <option value="부산">부산</option>
+          <option value="기타">기타</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="form-section">
+      <h3>🎯 계획 목표</h3>
+      <div class="field">
+        <label>목표 인구 (명, 0=자동)</label>
+        <input type="number" id="target-pop" value="0" min="0">
+      </div>
+      <div class="field">
+        <label>목표 용적률 (%)</label>
+        <input type="number" id="target-far" value="200" min="0" max="1500">
+      </div>
+      <div class="field">
+        <label>최소 녹지율 (%)</label>
+        <input type="number" id="green-ratio" value="10" min="5" max="40">
+      </div>
+      <div class="field">
+        <label>도로율 목표 (%)</label>
+        <input type="number" id="road-ratio" value="25" min="15" max="35">
+      </div>
+      <div class="field">
+        <label>대중교통 접근성</label>
+        <select id="transit">
+          <option value="없음">없음</option>
+          <option value="버스">버스</option>
+          <option value="지하철">지하철</option>
+          <option value="복합">복합(버스+지하철)</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="form-section">
+      <h3>⚖ 설계 우선순위</h3>
+      <div class="priority-row">
+        <label>밀도</label>
+        <input type="range" min="1" max="5" value="3" id="p-density" oninput="document.getElementById('v-density').textContent=this.value">
+        <span id="v-density">3</span>
+      </div>
+      <div class="priority-row">
+        <label>녹지</label>
+        <input type="range" min="1" max="5" value="3" id="p-green" oninput="document.getElementById('v-green').textContent=this.value">
+        <span id="v-green">3</span>
+      </div>
+      <div class="priority-row">
+        <label>보행성</label>
+        <input type="range" min="1" max="5" value="3" id="p-walk" oninput="document.getElementById('v-walk').textContent=this.value">
+        <span id="v-walk">3</span>
+      </div>
+      <div class="priority-row">
+        <label>공공시설</label>
+        <input type="range" min="1" max="5" value="3" id="p-public" oninput="document.getElementById('v-public').textContent=this.value">
+        <span id="v-public">3</span>
+      </div>
+      <div class="priority-row">
+        <label>교통</label>
+        <input type="range" min="1" max="5" value="3" id="p-traffic" oninput="document.getElementById('v-traffic').textContent=this.value">
+        <span id="v-traffic">3</span>
+      </div>
+    </div>
+
+    <button id="btn-draw" onclick="startDraw()">✏ 대상지 경계 그리기</button>
+    <button id="btn-plan" onclick="runPlan()" disabled>▶ 토지이용계획 수립</button>
+    <button id="btn-clear" onclick="clearAll()">🗑 초기화</button>
+  </div>
+  <div class="status-bar" id="status-bar">대상지 경계를 그려 시작하세요.</div>
+</div>
+
+<!-- Map -->
+<div id="map-container">
+  <div id="map"></div>
+
+  <div class="layer-controls">
+    <h4>레이어 제어</h4>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-context-road" checked onchange="toggleLayer('contextRoad', this.checked)"> 주변 도로</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-context-lu" checked onchange="toggleLayer('contextLanduse', this.checked)"> 주변 토지이용</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-road" checked onchange="toggleLayer('road', this.checked)"> 계획 도로</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-zoning" checked onchange="toggleLayer('zoning', this.checked)"> 용도지역</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-facility" checked onchange="toggleLayer('facility', this.checked)"> 공공시설</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-block-label" checked onchange="toggleLayer('blockLabel', this.checked)"> 블록 라벨</label>
+    <label class="layer-toggle"><input type="checkbox" id="lyr-subway" checked onchange="toggleLayer('subway', this.checked)"> 지하철역</label>
+  </div>
+
+  <div class="map-legend" id="map-legend" style="display:none">
+    <h4>용도지역 범례</h4>
+    <div id="legend-items"></div>
+  </div>
+</div>
+
+<!-- Right Panel -->
+<div id="right-panel">
+  <h2>📊 분석 결과
+  </h2>
+  <div class="tabs">
+    <button class="tab-btn active" onclick="switchTab('stats')">통계</button>
+    <button class="tab-btn" onclick="switchTab('validation')">검증</button>
+    <button class="tab-btn" onclick="switchTab('context')">맥락</button>
+    <button class="tab-btn" onclick="switchTab('report')">보고서</button>
+  </div>
+
+  <!-- STATS TAB -->
+  <div class="tab-content active" id="tab-stats">
+    <div style="color:#555; font-size:12px; text-align:center; padding:30px 0;" id="stats-placeholder">
+      계획 수립 후 결과가 표시됩니다.
+    </div>
+    <div id="stats-content" style="display:none">
+      <div class="stat-card">
+        <h4>🏠 대상지 현황</h4>
+        <div class="stat-row"><span class="stat-label">면적</span><span class="stat-value" id="s-area">-</span></div>
+        <div class="stat-row"><span class="stat-label">둘레</span><span class="stat-value" id="s-perimeter">-</span></div>
+        <div class="stat-row"><span class="stat-label">형상지수</span><span class="stat-value" id="s-shape">-</span></div>
+        <div class="stat-row"><span class="stat-label">진입점</span><span class="stat-value" id="s-entry">-</span></div>
+        <div class="stat-row"><span class="stat-label">블록 수</span><span class="stat-value" id="s-blocks">-</span></div>
+      </div>
+
+      <div class="stat-card">
+        <h4>🛣 도로율</h4>
+        <div class="gauge-bar-wrap">
+          <div class="gauge-label"><span>현재</span><span id="gauge-road-val">0%</span></div>
+          <div class="gauge-track">
+            <div class="gauge-fill" id="gauge-road" style="width:0%"></div>
+          </div>
+          <div style="font-size:9px; color:#555; margin-top:2px;">기준: 20~30% (빨강=기준 외)</div>
+        </div>
+        <div class="stat-row"><span class="stat-label">총 도로 연장</span><span class="stat-value" id="s-road-len">-</span></div>
+        <div class="stat-row"><span class="stat-label">도로 면적</span><span class="stat-value" id="s-road-area">-</span></div>
+      </div>
+
+      <div class="stat-card">
+        <h4>🌿 녹지율</h4>
+        <div class="gauge-bar-wrap">
+          <div class="gauge-label"><span>현재</span><span id="gauge-green-val">0%</span></div>
+          <div class="gauge-track">
+            <div class="gauge-fill" id="gauge-green" style="width:0%"></div>
+          </div>
+          <div style="font-size:9px; color:#555; margin-top:2px;">기준: 최소 10%</div>
+        </div>
+      </div>
+
+      <div class="stat-card">
+        <h4>🏘 용도지역 배분</h4>
+        <table class="zoning-table" id="zoning-table">
+          <thead><tr><th></th><th>용도</th><th>면적(ha)</th><th>비율</th></tr></thead>
+          <tbody id="zoning-tbody"></tbody>
+        </table>
+      </div>
+
+      <div class="stat-card">
+        <h4>👥 수용 능력 추정</h4>
+        <div class="stat-row"><span class="stat-label">추정 세대수</span><span class="stat-value" id="s-households">-</span></div>
+        <div class="stat-row"><span class="stat-label">추정 인구</span><span class="stat-value" id="s-population">-</span></div>
+        <div class="stat-row"><span class="stat-label">1인당 녹지</span><span class="stat-value" id="s-green-per">-</span></div>
+        <div class="stat-row"><span class="stat-label">공원 250m 커버</span><span class="stat-value" id="s-park-cov">-</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- VALIDATION TAB -->
+  <div class="tab-content" id="tab-validation">
+    <div style="color:#555; font-size:12px; text-align:center; padding:30px 0;" id="val-placeholder">
+      계획 수립 후 결과가 표시됩니다.
+    </div>
+    <div id="val-content" style="display:none">
+      <div class="score-circle" id="score-circle">
+        <div class="score-num" id="score-num">0</div>
+        <div class="score-label">종합 점수</div>
+      </div>
+      <div class="section-header">필수 검토 항목</div>
+      <ul class="check-list" id="required-list"></ul>
+      <div class="section-header" style="margin-top:10px">권장 검토 항목</div>
+      <ul class="check-list" id="recommended-list"></ul>
+    </div>
+  </div>
+
+  <!-- CONTEXT TAB -->
+  <div class="tab-content" id="tab-context">
+    <div style="color:#555; font-size:12px; text-align:center; padding:30px 0;" id="ctx-placeholder">
+      계획 수립 후 결과가 표시됩니다.
+    </div>
+    <div id="ctx-content" style="display:none">
+      <div class="stat-card">
+        <h4>🧭 주변 용도</h4>
+        <div class="compass-grid">
+          <div></div>
+          <div class="compass-cell"><span class="compass-dir">북</span><span class="compass-use" id="adj-n">-</span></div>
+          <div></div>
+          <div class="compass-cell"><span class="compass-dir">서</span><span class="compass-use" id="adj-w">-</span></div>
+          <div class="compass-cell center"><span class="compass-dir">대상지</span><span class="compass-use">📍</span></div>
+          <div class="compass-cell"><span class="compass-dir">동</span><span class="compass-use" id="adj-e">-</span></div>
+          <div></div>
+          <div class="compass-cell"><span class="compass-dir">남</span><span class="compass-use" id="adj-s">-</span></div>
+          <div></div>
+        </div>
+        <div class="stat-row"><span class="stat-label">주변 지배 용도</span><span class="stat-value" id="dominant-use">-</span></div>
+      </div>
+
+      <div class="stat-card">
+        <h4>🚇 대중교통</h4>
+        <div class="stat-row"><span class="stat-label">최근 지하철역</span><span class="stat-value" id="subway-name">-</span></div>
+        <div class="stat-row"><span class="stat-label">지하철까지 거리</span><span class="stat-value" id="subway-dist">-</span></div>
+        <div class="stat-row"><span class="stat-label">역세권 여부</span><span class="stat-value" id="tod-zone">-</span></div>
+      </div>
+
+      <div class="stat-card">
+        <h4>🚪 진입점 목록</h4>
+        <div id="entry-list">진입점 없음</div>
+      </div>
+
+      <div class="stat-card">
+        <h4>💡 설계 권고사항</h4>
+        <div id="recommendations">-</div>
+      </div>
+
+      <div class="stat-card">
+        <h4>📚 유사 사례</h4>
+        <div id="similar-cases">-</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- REPORT TAB -->
+  <div class="tab-content" id="tab-report">
+    <div style="color:#555; font-size:12px; text-align:center; padding:30px 0;" id="rpt-placeholder">
+      계획 수립 후 결과가 표시됩니다.
+    </div>
+    <div id="rpt-content" style="display:none">
+      <button id="btn-export" onclick="exportReport()">📄 보고서 내보내기</button>
+      <div class="report-section">
+        <h4>📋 계획 개요</h4>
+        <div class="report-text" id="rpt-overview"></div>
+      </div>
+      <div class="report-section">
+        <h4>🗺 토지이용 계획</h4>
+        <div class="report-text" id="rpt-rationale"></div>
+      </div>
+      <div class="report-section">
+        <h4>🛣 도로망 계획</h4>
+        <div class="report-text" id="rpt-roads"></div>
+      </div>
+      <div class="report-section">
+        <h4>🏫 공공시설 계획</h4>
+        <div class="report-text" id="rpt-facilities"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Loading Overlay -->
+<div id="loading-overlay">
+  <div class="spinner"></div>
+  <div class="loading-msg" id="loading-msg">계획 수립 중...</div>
+  <div class="loading-steps" id="loading-steps">OSM 데이터 수집 중</div>
+</div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
+<script>
+// =====================================================
+// CONSTANTS
+// =====================================================
+const ZONING_COLORS = {
+  'R1': '#FFE4E1', 'R2': '#FFCDD2',
+  'R3': '#FFB3BA', 'R4': '#FF8FAB',
+  'R5': '#FF69B4', 'RQ': '#DDA0DD',
+  'CB': '#FF2400', 'CG': '#FF4500',
+  'CN': '#FF8C00', 'IQ': '#A9A9A9',
+  'GN': '#228B22', 'PK': '#90EE90',
+  'PF': '#4169E1', 'ROAD': '#CCCCCC'
+};
+
+const LANDUSE_COLORS = {
+  'residential': '#FFB3BA', 'commercial': '#FFA07A',
+  'industrial': '#A9A9A9', 'farmland': '#DEB887',
+  'forest': '#228B22', 'grass': '#7CFC00',
+  'park': '#90EE90', 'recreation_ground': '#90EE90',
+  'school': '#87CEEB', 'hospital': '#FFB6C1',
+};
+
+const FACILITY_COLORS_MAP = {
+  'neighborhood_park': '#2ECC71',
+  'children_park': '#27AE60',
+  'elementary_school': '#3498DB',
+  'middle_school': '#2980B9',
+  'high_school': '#1ABC9C',
+  'community_center': '#E74C3C',
+  'welfare_center': '#E67E22',
+};
+
+const FACILITY_NAMES = {
+  'neighborhood_park': '근린공원',
+  'children_park': '어린이공원',
+  'elementary_school': '초등학교',
+  'middle_school': '중학교',
+  'high_school': '고등학교',
+  'community_center': '주민센터',
+  'welfare_center': '복지관',
+};
+
+const ROAD_HIERARCHY_STYLE = {
+  'primary': { weight: 8, color: '#555555', opacity: 0.9 },
+  'secondary': { weight: 5, color: '#777777', opacity: 0.85 },
+  'local': { weight: 3, color: '#999999', opacity: 0.8 },
+};
+
+// =====================================================
+// MAP SETUP
+// =====================================================
+const map = L.map('map', {
+  center: [37.5665, 126.9780],
+  zoom: 14,
+  zoomControl: true,
+});
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '© OpenStreetMap © CARTO',
+  maxZoom: 20,
+}).addTo(map);
+
+// Draw control
+const drawnItems = new L.FeatureGroup().addTo(map);
+const drawControl = new L.Control.Draw({
+  edit: { featureGroup: drawnItems, remove: true },
+  draw: {
+    polygon: {
+      allowIntersection: false,
+      showArea: true,
+      shapeOptions: { color: '#e94560', fillColor: '#e94560', fillOpacity: 0.2 }
+    },
+    rectangle: {
+      shapeOptions: { color: '#e94560', fillColor: '#e94560', fillOpacity: 0.2 }
+    },
+    circle: false, marker: false, circlemarker: false, polyline: false,
+  }
+});
+
+map.on(L.Draw.Event.CREATED, function(e) {
+  drawnItems.clearLayers();
+  drawnItems.addLayer(e.layer);
+  document.getElementById('btn-plan').disabled = false;
+  setStatus('경계가 그려졌습니다. 계획 수립 버튼을 클릭하세요.', 'success');
+  // Fit map to drawn boundary
+  map.fitBounds(e.layer.getBounds(), { padding: [50, 50] });
+});
+
+map.on(L.Draw.Event.EDITED, function() {
+  document.getElementById('btn-plan').disabled = false;
+});
+
+// Layer groups
+const layers = {
+  contextRoad: L.layerGroup().addTo(map),
+  contextLanduse: L.layerGroup().addTo(map),
+  road: L.layerGroup().addTo(map),
+  zoning: L.layerGroup().addTo(map),
+  facility: L.layerGroup().addTo(map),
+  blockLabel: L.layerGroup().addTo(map),
+  subway: L.layerGroup().addTo(map),
+  entryPoint: L.layerGroup().addTo(map),
+};
+
+function toggleLayer(name, visible) {
+  if (visible) map.addLayer(layers[name]);
+  else map.removeLayer(layers[name]);
+}
+
+// =====================================================
+// UI HELPERS
+// =====================================================
+function setStatus(msg, type = '') {
+  const el = document.getElementById('status-bar');
+  el.textContent = msg;
+  el.className = 'status-bar ' + type;
+}
+
+function switchTab(name) {
+  document.querySelectorAll('.tab-btn').forEach((b, i) => {
+    b.classList.toggle('active', ['stats','validation','context','report'][i] === name);
+  });
+  document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+  document.getElementById('tab-' + (name === 'stats' ? 'stats' : name === 'validation' ? 'validation' : name === 'context' ? 'context' : 'report')).classList.add('active');
+}
+
+function startDraw() {
+  new L.Draw.Polygon(map, drawControl.options.draw.polygon).enable();
+  setStatus('지도 위 대상지 경계를 클릭해 그리세요. 더블클릭으로 완료.', '');
+}
+
+function clearAll() {
+  drawnItems.clearLayers();
+  Object.values(layers).forEach(l => l.clearLayers());
+  document.getElementById('btn-plan').disabled = true;
+  document.getElementById('map-legend').style.display = 'none';
+  ['stats-content', 'val-content', 'ctx-content', 'rpt-content'].forEach(id => {
+    document.getElementById(id).style.display = 'none';
+  });
+  ['stats-placeholder', 'val-placeholder', 'ctx-placeholder', 'rpt-placeholder'].forEach(id => {
+    document.getElementById(id).style.display = 'block';
+  });
+  setStatus('초기화되었습니다. 대상지 경계를 그려 시작하세요.', '');
+}
+
+// =====================================================
+// GET BOUNDARY GEOJSON
+// =====================================================
+function getBoundaryGeoJSON() {
+  const l = drawnItems.getLayers();
+  if (!l.length) return null;
+  const layer = l[0];
+  const latlngs = layer.getLatLngs ? layer.getLatLngs() : null;
+  if (!latlngs) return null;
+
+  // Flatten to simple ring
+  let coords;
+  if (Array.isArray(latlngs[0]) && Array.isArray(latlngs[0][0])) {
+    coords = latlngs[0][0].map(ll => [ll.lng, ll.lat]);
+  } else if (Array.isArray(latlngs[0])) {
+    coords = latlngs[0].map(ll => [ll.lng, ll.lat]);
+  } else {
+    coords = latlngs.map(ll => [ll.lng, ll.lat]);
+  }
+
+  // Close ring
+  if (coords[0][0] !== coords[coords.length-1][0] || coords[0][1] !== coords[coords.length-1][1]) {
+    coords.push(coords[0]);
+  }
+
+  return { type: 'Polygon', coordinates: [coords] };
+}
+
+// =====================================================
+// MAIN PLAN FUNCTION
+// =====================================================
+async function runPlan() {
+  const boundary = getBoundaryGeoJSON();
+  if (!boundary) { setStatus('대상지 경계를 먼저 그려주세요.', 'error'); return; }
+
+  const overlay = document.getElementById('loading-overlay');
+  overlay.classList.add('show');
+
+  const steps = [
+    'OSM 데이터 수집 중...',
+    '현황 분석 중...',
+    '도로망 생성 중...',
+    '블록 분할 중...',
+    '용도지역 배치 중...',
+    '공공시설 배치 중...',
+    '법규 검증 중...',
+  ];
+  let stepIdx = 0;
+  const stepInterval = setInterval(() => {
+    if (stepIdx < steps.length) {
+      document.getElementById('loading-steps').textContent = steps[stepIdx++];
+    }
+  }, 1500);
+
+  try {
+    setStatus('계획 수립 중...', '');
+    const payload = {
+      boundary_geojson: boundary,
+      site_name: document.getElementById('site-name').value,
+      development_type: document.getElementById('dev-type').value,
+      program: document.getElementById('program').value,
+      target_population: parseInt(document.getElementById('target-pop').value) || 0,
+      target_far: parseFloat(document.getElementById('target-far').value) || 200,
+      green_ratio_min: (parseFloat(document.getElementById('green-ratio').value) || 10) / 100,
+      road_ratio_target: (parseFloat(document.getElementById('road-ratio').value) || 25) / 100,
+      region: document.getElementById('region').value,
+      transit_access: document.getElementById('transit').value,
+      priority: {
+        density: parseInt(document.getElementById('p-density').value),
+        green: parseInt(document.getElementById('p-green').value),
+        walkability: parseInt(document.getElementById('p-walk').value),
+        publicfacility: parseInt(document.getElementById('p-public').value),
+        traffic: parseInt(document.getElementById('p-traffic').value),
+      }
+    };
+
+    const res = await fetch('/api/plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const json = await res.json();
+
+    if (!json.success) {
+      setStatus('오류: ' + json.error, 'error');
+      console.error(json.traceback);
+      return;
+    }
+
+    // Render results
+    renderResults(json.data, boundary);
+    setStatus('✅ 토지이용계획 수립 완료!', 'success');
+
+  } catch (err) {
+    setStatus('네트워크 오류: ' + err.message, 'error');
+    console.error(err);
+  } finally {
+    clearInterval(stepInterval);
+    overlay.classList.remove('show');
+  }
+}
+
+// =====================================================
+// RENDER ALL RESULTS
+// =====================================================
+function renderResults(data, boundary) {
+  // Clear layers
+  Object.values(layers).forEach(l => l.clearLayers());
+
+  // Layer 1: Context landuse (dotted background)
+  if (data.context_geojson && data.context_geojson.landuse) {
+    try {
+      const luData = JSON.parse(data.context_geojson.landuse);
+      L.geoJSON(luData, {
+        style: f => {
+          const lu = f.properties.landuse || '';
+          const color = LANDUSE_COLORS[lu] || '#888888';
+          return { color: '#aaa', weight: 1, dashArray: '4,3', fillColor: color, fillOpacity: 0.15 };
+        },
+        onEachFeature: (f, l) => {
+          const name = f.properties.name || f.properties.landuse || '';
+          if (name) l.bindTooltip(name, { permanent: false, direction: 'center', className: 'block-label' });
+        }
+      }).addTo(layers.contextLanduse);
+    } catch(e) { console.warn('Context landuse error:', e); }
+  }
+
+  // Layer 2: Context roads (dotted orange)
+  if (data.context_geojson && data.context_geojson.roads) {
+    try {
+      const rdData = JSON.parse(data.context_geojson.roads);
+      L.geoJSON(rdData, {
+        style: { color: '#FF6600', weight: 2, dashArray: '6,4', opacity: 0.5 },
+      }).addTo(layers.contextRoad);
+    } catch(e) { console.warn('Context road error:', e); }
+  }
+
+  // Layer 3: Planned roads (solid, by hierarchy)
+  if (data.roads && data.roads.features) {
+    L.geoJSON(data.roads, {
+      style: f => {
+        const hier = f.properties.hierarchy || 'local';
+        const s = ROAD_HIERARCHY_STYLE[hier] || ROAD_HIERARCHY_STYLE.local;
+        return { ...s, fillColor: '#888', fillOpacity: 0.7 };
+      },
+      onEachFeature: (f, l) => {
+        const hier = f.properties.hierarchy || '';
+        const w = f.properties.width_m || '';
+        const names = { primary:'주간선', secondary:'보조간선', local:'국지도로' };
+        l.bindTooltip(`${names[hier]||hier} (${w}m)`, { sticky: true });
+      }
+    }).addTo(layers.road);
+  }
+
+  // Layer 4: Zoning polygons
+  const zoningPresent = {};
+  if (data.zoning && data.zoning.features) {
+    L.geoJSON(data.zoning, {
+      style: f => {
+        const code = f.properties.zone_code || 'R4';
+        const color = ZONING_COLORS[code] || '#888';
+        return { color: '#333', weight: 1.5, fillColor: color, fillOpacity: 0.6 };
+      },
+      onEachFeature: (f, l) => {
+        const code = f.properties.zone_code || '';
+        const name = f.properties.zone_name || code;
+        const area = (f.properties.area_m2 / 10000).toFixed(2);
+        l.bindTooltip(`${name}<br>${area}ha`, { sticky: true });
+        zoningPresent[code] = f.properties.zone_name || code;
+      }
+    }).addTo(layers.zoning);
+  }
+
+  // Layer 5: Facilities (Polygon only - NO circles!)
+  if (data.facilities && data.facilities.features) {
+    L.geoJSON(data.facilities, {
+      style: f => {
+        const ftype = f.properties.facility_type || '';
+        const color = FACILITY_COLORS_MAP[ftype] || '#4169E1';
+        return { color: '#fff', weight: 2, fillColor: color, fillOpacity: 0.85 };
+      },
+      onEachFeature: (f, l) => {
+        const name = FACILITY_NAMES[f.properties.facility_type] || f.properties.facility_name || f.properties.facility_type;
+        const area = f.properties.area_m2 ? (f.properties.area_m2/10000).toFixed(3) + 'ha' : '';
+        l.bindTooltip(`${name}${area ? ' ('+area+')' : ''}`, { permanent: false, direction: 'center' });
+      }
+    }).addTo(layers.facility);
+  }
+
+  // Layer 6: Entry point markers (red circle markers - these are UI markers, not facilities)
+  if (data.entry_points) {
+    data.entry_points.forEach(ep => {
+      const [lon, lat] = ep.point_wgs84;
+      const marker = L.circleMarker([lat, lon], {
+        radius: 8, color: '#e94560', fillColor: '#e94560', fillOpacity: 0.9, weight: 2
+      });
+      const roadName = ep.road_name || '미명도로';
+      marker.bindTooltip(`진입점: ${roadName}<br>폭원: ${ep.road_width_m}m<br>방향: ${ep.angle_deg.toFixed(0)}°`, { direction: 'top' });
+      marker.addTo(layers.entryPoint);
+    });
+  }
+
+  // Layer 7: Block labels
+  if (data.blocks && data.blocks.features) {
+    data.blocks.features.forEach(f => {
+      if (f.geometry && f.geometry.type === 'Polygon') {
+        const coords = f.geometry.coordinates[0];
+        let lat = 0, lng = 0;
+        coords.forEach(c => { lng += c[0]; lat += c[1]; });
+        lat /= coords.length; lng /= coords.length;
+        const bid = f.properties.block_id || '';
+        const label = L.marker([lat, lng], {
+          icon: L.divIcon({
+            className: 'block-label',
+            html: `<span>${bid}</span>`,
+            iconSize: [40, 14],
+            iconAnchor: [20, 7],
+          }),
+          interactive: false,
+        });
+        label.addTo(layers.blockLabel);
+      }
+    });
+  }
+
+  // Layer 8: Subway station emoji markers
+  if (data.subway_stations) {
+    data.subway_stations.forEach(st => {
+      const icon = L.divIcon({
+        className: '',
+        html: `<div style="font-size:18px; text-shadow:0 0 3px #000;">🚇</div>`,
+        iconSize: [24, 24], iconAnchor: [12, 12],
+      });
+      L.marker([st.lat, st.lon], { icon })
+        .bindTooltip(st.name, { direction: 'top' })
+        .addTo(layers.subway);
+    });
+  }
+
+  // Fit map to boundary
+  try {
+    const coords = boundary.coordinates[0].map(c => [c[1], c[0]]);
+    map.fitBounds(L.latLngBounds(coords), { padding: [30, 30] });
+  } catch(e) {}
+
+  // Update legend
+  updateLegend(zoningPresent);
+
+  // Update stats panel
+  updateStats(data);
+  updateValidation(data.validation);
+  updateContext(data);
+  updateReport(data);
+}
+
+// =====================================================
+// UPDATE LEGEND
+// =====================================================
+function updateLegend(zoningPresent) {
+  const legend = document.getElementById('map-legend');
+  const items = document.getElementById('legend-items');
+  items.innerHTML = '';
+
+  Object.entries(zoningPresent).forEach(([code, name]) => {
+    const color = ZONING_COLORS[code] || '#888';
+    items.innerHTML += `
+      <div class="legend-item">
+        <div class="legend-color" style="background:${color}"></div>
+        <span>${name}</span>
+      </div>`;
+  });
+
+  // Add facility legend
+  items.innerHTML += `<div style="margin-top:6px; font-size:10px; color:#e94560; font-weight:bold;">공공시설</div>`;
+  Object.entries(FACILITY_NAMES).forEach(([type, name]) => {
+    const color = FACILITY_COLORS_MAP[type] || '#888';
+    items.innerHTML += `
+      <div class="legend-item">
+        <div class="legend-color" style="background:${color}"></div>
+        <span>${name}</span>
+      </div>`;
+  });
+
+  legend.style.display = 'block';
+}
+
+// =====================================================
+// UPDATE STATS TAB
+// =====================================================
+function updateStats(data) {
+  document.getElementById('stats-placeholder').style.display = 'none';
+  document.getElementById('stats-content').style.display = 'block';
+
+  const sa = data.site_analysis || {};
+  document.getElementById('s-area').textContent = sa.area_ha ? `${sa.area_ha.toFixed(2)}ha (${Math.round(sa.area_m2).toLocaleString()}㎡)` : '-';
+  document.getElementById('s-perimeter').textContent = sa.perimeter_m ? `${sa.perimeter_m.toFixed(0)}m` : '-';
+  document.getElementById('s-shape').textContent = sa.shape_index ? sa.shape_index.toFixed(3) : '-';
+  document.getElementById('s-entry').textContent = (data.entry_points || []).length + '개';
+  document.getElementById('s-blocks').textContent = (data.block_stats || {}).count || '-';
+
+  // Road gauge
+  const rs = data.road_stats || {};
+  const roadPct = ((rs.road_ratio || 0) * 100);
+  const roadGood = roadPct >= 20 && roadPct <= 30;
+  document.getElementById('gauge-road-val').textContent = roadPct.toFixed(1) + '%';
+  const gaugeRoad = document.getElementById('gauge-road');
+  gaugeRoad.style.width = Math.min(roadPct * 2, 100) + '%';
+  gaugeRoad.className = 'gauge-fill ' + (roadGood ? 'good' : 'bad');
+  document.getElementById('s-road-len').textContent = rs.total_length_m ? (rs.total_length_m / 1000).toFixed(2) + 'km' : '-';
+  document.getElementById('s-road-area').textContent = rs.road_area_m2 ? Math.round(rs.road_area_m2).toLocaleString() + '㎡' : '-';
+
+  // Green gauge
+  const zs = data.zoning_stats || {};
+  let greenArea = 0;
+  Object.entries(zs).forEach(([code, stat]) => {
+    if (['GN', 'PK'].includes(code)) greenArea += stat.area_m2 || 0;
+  });
+  const totalArea = sa.area_m2 || 1;
+  const greenPct = (greenArea / totalArea * 100);
+  const greenGood = greenPct >= 10;
+  document.getElementById('gauge-green-val').textContent = greenPct.toFixed(1) + '%';
+  const gaugeGreen = document.getElementById('gauge-green');
+  gaugeGreen.style.width = Math.min(greenPct * 2.5, 100) + '%';
+  gaugeGreen.className = 'gauge-fill ' + (greenGood ? 'good' : 'bad');
+
+  // Zoning table
+  const tbody = document.getElementById('zoning-tbody');
+  tbody.innerHTML = '';
+  Object.entries(zs).sort((a,b) => (b[1].area_m2||0) - (a[1].area_m2||0)).forEach(([code, stat]) => {
+    const color = ZONING_COLORS[code] || '#888';
+    tbody.innerHTML += `<tr>
+      <td><span class="zoning-color-cell" style="background:${color}; border:1px solid #333"></span></td>
+      <td>${stat.name || code}</td>
+      <td>${(stat.area_ha||0).toFixed(2)}</td>
+      <td>${((stat.ratio||0)*100).toFixed(1)}%</td>
+    </tr>`;
+  });
+
+  // Population estimates
+  let resArea = 0, resHouseholds = 0;
+  Object.entries(zs).forEach(([code, stat]) => {
+    if (['R1','R2','R3','R4','R5','RQ'].includes(code)) {
+      const area = stat.area_m2 || 0;
+      const far = stat.far_max || 150;
+      // Rough: 50% BCR, floor area * 0.5 / 60 sqm per household
+      const floorArea = area * (far / 100) * 0.5;
+      resHouseholds += floorArea / 60;
+      resArea += area;
+    }
+  });
+  const estPop = Math.round(resHouseholds * 2.5);
+  document.getElementById('s-households').textContent = Math.round(resHouseholds).toLocaleString() + ' 세대';
+  document.getElementById('s-population').textContent = estPop.toLocaleString() + ' 명';
+
+  const greenPerPerson = estPop > 0 ? (greenArea / estPop).toFixed(1) : '-';
+  document.getElementById('s-green-per').textContent = greenPerPerson + '㎡/인';
+
+  const cov = data.coverage || {};
+  document.getElementById('s-park-cov').textContent = ((cov.park_250m_ratio || 0) * 100).toFixed(1) + '%';
+}
+
+// =====================================================
+// UPDATE VALIDATION TAB
+// =====================================================
+function updateValidation(val) {
+  if (!val) return;
+  document.getElementById('val-placeholder').style.display = 'none';
+  document.getElementById('val-content').style.display = 'block';
+
+  const score = val.score || 0;
+  document.getElementById('score-num').textContent = score;
+  const circle = document.getElementById('score-circle');
+  const color = score >= 80 ? '#2ecc71' : score >= 60 ? '#f39c12' : '#e94560';
+  circle.style.borderColor = color;
+  document.getElementById('score-num').style.color = color;
+
+  function renderChecks(items, containerId) {
+    const container = document.getElementById(containerId);
+    container.innerHTML = '';
+    items.forEach(item => {
+      const passClass = item.pass ? 'pass' : 'fail';
+      const icon = item.pass ? '✅' : '❌';
+      container.innerHTML += `
+        <li class="check-item ${passClass}">
+          <span class="icon">${icon}</span>
+          <div>
+            <div>${item.item}</div>
+            <div class="detail">${item.value} / 기준: ${item.standard}</div>
+          </div>
+        </li>`;
+    });
+  }
+
+  renderChecks(val.required || [], 'required-list');
+  renderChecks(val.recommended || [], 'recommended-list');
+}
+
+// =====================================================
+// UPDATE CONTEXT TAB
+// =====================================================
+function updateContext(data) {
+  document.getElementById('ctx-placeholder').style.display = 'none';
+  document.getElementById('ctx-content').style.display = 'block';
+
+  const ca = data.context_analysis || {};
+  document.getElementById('adj-n').textContent = ca.adjacent_use_north || '-';
+  document.getElementById('adj-s').textContent = ca.adjacent_use_south || '-';
+  document.getElementById('adj-e').textContent = ca.adjacent_use_east || '-';
+  document.getElementById('adj-w').textContent = ca.adjacent_use_west || '-';
+  document.getElementById('dominant-use').textContent = ca.dominant_surrounding_use || '-';
+  document.getElementById('subway-name').textContent = ca.nearest_subway_name || '없음';
+  document.getElementById('subway-dist').textContent = ca.nearest_subway_m ? ca.nearest_subway_m.toFixed(0) + 'm' : '-';
+  document.getElementById('tod-zone').textContent = ca.is_tod_zone ? '✅ 역세권(500m 이내)' : '❌ 비역세권';
+
+  // Entry points
+  const entries = data.entry_points || [];
+  const entryEl = document.getElementById('entry-list');
+  if (entries.length === 0) {
+    entryEl.innerHTML = '<span style="color:#555">기존 도로 진입점 없음</span>';
+  } else {
+    entryEl.innerHTML = entries.map(ep => {
+      const rn = ep.road_name || '미명도로';
+      return `<div class="info-badge active">🚗 ${rn} (${ep.road_width_m}m)</div>`;
+    }).join('');
+  }
+
+  // Recommendations
+  const recs = ca.recommendations || [];
+  const recEl = document.getElementById('recommendations');
+  if (recs.length === 0) {
+    recEl.innerHTML = '<span style="color:#555">권고사항 없음</span>';
+  } else {
+    recEl.innerHTML = recs.map(r => `<div class="rec-item">💡 ${r}</div>`).join('');
+  }
+
+  // Similar cases
+  const cases = (data.site_analysis || {}).similar_cases || [];
+  const caseEl = document.getElementById('similar-cases');
+  if (cases.length === 0) {
+    caseEl.innerHTML = '<span style="color:#555">유사 사례 없음</span>';
+  } else {
+    caseEl.innerHTML = cases.map(c => `
+      <div style="background:#0f3460; border-radius:4px; padding:7px; margin-bottom:5px; font-size:11px;">
+        <div style="color:#e94560; font-weight:bold;">${c.name} <span style="color:#aaa; font-weight:normal;">(유사도 ${((c.similarity_score||0)*100).toFixed(0)}%)</span></div>
+        <div style="color:#aaa; margin-top:2px;">${c.area_ha}ha / ${c.population.toLocaleString()}명</div>
+        <div style="color:#888; margin-top:2px; font-size:10px;">${c.lessons || ''}</div>
+      </div>`).join('');
+  }
+}
+
+// =====================================================
+// UPDATE REPORT TAB
+// =====================================================
+function updateReport(data) {
+  document.getElementById('rpt-placeholder').style.display = 'none';
+  document.getElementById('rpt-content').style.display = 'block';
+
+  const sa = data.site_analysis || {};
+  const ca = data.context_analysis || {};
+  const rs = data.road_stats || {};
+  const zs = data.zoning_stats || {};
+  const siteName = document.getElementById('site-name').value;
+  const devType = document.getElementById('dev-type').value;
+  const program = document.getElementById('program').value;
+
+  // Overview
+  document.getElementById('rpt-overview').textContent =
+    `계획 구역: ${siteName}\n` +
+    `개발 유형: ${devType} / 프로그램: ${program}\n` +
+    `대상지 면적: ${(sa.area_ha||0).toFixed(2)}ha\n` +
+    `형상지수: ${(sa.shape_index||0).toFixed(3)} (1에 가까울수록 정형)\n` +
+    `진입점: ${(data.entry_points||[]).length}개\n` +
+    `지형: ${sa.terrain_type || '평지'}`;
+
+  // Rationale
+  document.getElementById('rpt-rationale').textContent = data.design_rationale || '-';
+
+  // Roads
+  const roadLines = [];
+  Object.entries(rs.by_hierarchy || {}).forEach(([h, info]) => {
+    const names = {primary:'주간선도로', secondary:'보조간선도로', local:'국지도로'};
+    roadLines.push(`${names[h]||h}: ${info.count}개 / ${(info.total_length_m/1000).toFixed(2)}km`);
+  });
+  document.getElementById('rpt-roads').textContent =
+    `총 도로 연장: ${(rs.total_length_m/1000).toFixed(2)}km\n` +
+    `도로 면적: ${Math.round(rs.road_area_m2||0).toLocaleString()}㎡\n` +
+    `도로율: ${((rs.road_ratio||0)*100).toFixed(1)}%\n\n` +
+    roadLines.join('\n');
+
+  // Facilities
+  const fac = data.facilities || {};
+  const facFeatures = fac.features || [];
+  const facCounts = {};
+  facFeatures.forEach(f => {
+    const ft = f.properties.facility_type || '기타';
+    facCounts[ft] = (facCounts[ft] || 0) + 1;
+  });
+  const cov = data.coverage || {};
+  const facLines = Object.entries(facCounts).map(([k,v]) => {
+    return `${FACILITY_NAMES[k]||k}: ${v}개`;
+  });
+  document.getElementById('rpt-facilities').textContent =
+    facLines.join('\n') + '\n\n' +
+    `공원 250m 커버리지: ${((cov.park_250m_ratio||0)*100).toFixed(1)}%\n` +
+    `공원 500m 커버리지: ${((cov.park_500m_ratio||0)*100).toFixed(1)}%\n` +
+    `학교 500m 커버리지: ${((cov.school_500m_ratio||0)*100).toFixed(1)}%`;
+}
+
+// =====================================================
+// EXPORT REPORT
+// =====================================================
+function exportReport() {
+  const siteName = document.getElementById('site-name').value;
+  const overview = document.getElementById('rpt-overview').textContent;
+  const rationale = document.getElementById('rpt-rationale').textContent;
+  const roads = document.getElementById('rpt-roads').textContent;
+  const facilities = document.getElementById('rpt-facilities').textContent;
+
+  const content = `한국 도시설계 토지이용계획 보고서
+생성일: ${new Date().toLocaleDateString('ko-KR')}
+========================================
+
+1. 계획 개요
+${overview}
+
+2. 토지이용 계획
+${rationale}
+
+3. 도로망 계획
+${roads}
+
+4. 공공시설 계획
+${facilities}
+`;
+
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `토지이용계획_${siteName}_${new Date().toISOString().split('T')[0]}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// =====================================================
+// KEYBOARD SHORTCUTS
+// =====================================================
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    // Cancel drawing
+    map.off('click');
+  }
+});
+
+// Tab switching via keyboard
+document.querySelectorAll('.tab-btn').forEach((btn, i) => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+    btn.classList.add('active');
+    document.querySelectorAll('.tab-content')[i].classList.add('active');
+  });
+});
+
+// Initial status
+setStatus('✏ [대상지 경계 그리기] 버튼으로 시작하세요.', '');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 구현 내용

### Backend (FastAPI + Python)
- main.py: FastAPI 앱, /api/plan 및 /api/analyze 엔드포인트
- engine/context_fetcher.py: Overpass API로 주변 500m OSM 데이터 수집
  - 도로/토지이용/시설/지하철역/버스정류장 파싱
  - 진입점 탐지 (대상지 경계 교차 도로)
  - 주변 용도 분석 (북/남/동/서)
- engine/site_analyzer.py: 대상지 현황 분석
  - 면적/둘레/형상지수 계산 (EPSG:5179)
  - 유사 사례 매칭 (similarity_score 포함)
- engine/master_planner.py: 용도지역 배치
  - 용도별 목표 비율 계산 (프로그램/TOD/우선순위 반영)
  - 블록별 용도 배정 (R1~PF 13개 코드)
  - 경계 smoothing (dissolve + simplify)
- engine/road_generator.py: 3위계 도로망 생성
  - 주간선(20~35m) / 보조간선(12~20m) / 국지도로(6~12m)
  - 도로율 20~30% 자동 조정
- engine/block_divider.py: 도로로 블록 분할
  - 접면도로폭/코너블록 판정
- engine/facility_placer.py: 공공시설 배치
  - 근린공원/어린이공원/초중학교/주민센터 (Polygon만 사용)
  - 서비스 커버리지 계산
- engine/validator.py: 법규 검증 (필수5 + 권장5 항목, 100점 만점)

### Rules & Reference
- rules/zoning_rules.yaml: 서울시 용도지역 규정 (13개 코드)
- rules/road_rules.yaml: 도로 위계별 설계 기준
- rules/facility_rules.yaml: 공공시설 설치 기준
- reference/case_studies.json: 7개 신도시 사례 (미사/세종/송도/은평/광교/김포/판교)

### Frontend (static/index.html)
- 3패널 레이아웃 (좌300px 입력 | 중 Leaflet 지도 | 우350px 결과)
- Leaflet.draw로 대상지 경계 폴리곤 직접 그리기
- 8개 레이어: 주변도로(점선)/토지이용/계획도로/용도지역/공공시설/진입점/블록라벨/지하철
- 결과 패널 4탭: 통계/검증/맥락/보고서
- 도로율·녹지율 게이지바 (20~30% 녹색, 외 빨강)

### 핵심 원칙 준수
- 모든 GDF: EPSG:5179 통일 (입력 WGS84→변환→처리→출력 WGS84)
- Circle/Point 마커 금지: 공공시설 모두 블록 Polygon 그대로 사용
- 픽셀 루프 금지: 벡터 연산(shapely/geopandas)만 사용
- OSM 실패 시 빈 GDF 반환, 앱 정상 동작
- try/except로 모든 외부 API 감싸기

https://claude.ai/code/session_013wEB4yvx4dVjAxaXHGyfCd